### PR TITLE
Change the name of SMSSecure

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -6,7 +6,7 @@
     <uses-sdk tools:overrideLibrary="com.amulyakhare.textdrawable,com.astuetz.pagerslidingtabstrip,pl.tajchert.waitingdots"/>
 
     <permission android:name="org.smssecure.smssecure.ACCESS_SECRETS"
-                android:label="Access to SMSSecure Secrets"
+                android:label="Access to Silence Secrets"
                 android:protectionLevel="signature" />
 
     <uses-feature android:name="android.hardware.camera" android:required="false" />
@@ -41,9 +41,9 @@
                  android:supportsRtl="true"
                  tools:replace="android:allowBackup"
                  android:allowBackup="false"
-                 android:theme="@style/SMSSecure.LightTheme">
+                 android:theme="@style/Silence.LightTheme">
 
-    <meta-data android:name="org.smssecure.smssecure.mms.SMSSecureGlideModule"
+    <meta-data android:name="org.smssecure.smssecure.mms.SilenceGlideModule"
                android:value="GlideModule" />
 
     <activity android:name=".CountrySelectionActivity"
@@ -120,7 +120,7 @@
               android:launchMode="singleTask"
               android:taskAffinity=""
               android:excludeFromRecents="true"
-              android:theme="@style/SMSSecure.LightTheme.Popup"
+              android:theme="@style/Silence.LightTheme.Popup"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize" />
 
     <activity android:name=".MessageDetailsActivity"
@@ -151,19 +151,19 @@
     <activity android:name=".PassphraseCreateActivity"
               android:label="@string/AndroidManifest__create_passphrase"
               android:windowSoftInputMode="stateUnchanged"
-              android:theme="@style/SMSSecure.LightIntroTheme"
+              android:theme="@style/Silence.LightIntroTheme"
               android:launchMode="singleTask"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".PassphrasePromptActivity"
               android:label="@string/AndroidManifest__enter_passphrase"
               android:launchMode="singleTask"
-              android:theme="@style/SMSSecure.LightIntroTheme"
+              android:theme="@style/Silence.LightIntroTheme"
               android:windowSoftInputMode="stateAlwaysVisible"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".NewConversationActivity"
-              android:theme="@style/SMSSecure.LightNoActionBar"
+              android:theme="@style/Silence.LightNoActionBar"
               android:windowSoftInputMode="stateAlwaysVisible"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
@@ -230,11 +230,11 @@
     </activity>
 
     <activity android:name=".RecipientPreferenceActivity"
-              android:theme="@style/SMSSecure.LightNoActionBar"
+              android:theme="@style/Silence.LightNoActionBar"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <activity android:name=".BlockedContactsActivity"
-              android:theme="@style/SMSSecure.LightTheme"
+              android:theme="@style/Silence.LightTheme"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"/>
 
     <!-- this can never have launchMode singleTask or singleInstance! -->
@@ -341,6 +341,13 @@
     <receiver android:name=".notifications.MessageNotifier$DeleteReceiver">
         <intent-filter>
             <action android:name="org.smssecure.smssecure.MessageNotifier.DELETE_REMINDER_ACTION"/>
+        </intent-filter>
+    </receiver>
+
+    <receiver android:name=".IntroScreenActivity$AppUpgradeReceiver">
+        <intent-filter>
+            <action android:name="android.intent.action.PACKAGE_REPLACED"/>
+            <data android:scheme="package" />
         </intent-filter>
     </receiver>
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,20 +1,20 @@
-Building SMSSecure
-==================
+Building Silence
+================
 
 Basics
 ------
 
-SMSSecure uses [Gradle](http://gradle.org) to build the project and to maintain
+Silence uses [Gradle](http://gradle.org) to build the project and to maintain
 dependencies.
 
-Building SMSSecure
-------------------
+Building Silence
+----------------
 
-The following steps should help you (re)build SMSSecure from the command line.
+The following steps should help you (re)build Silence from the command line.
 
 1. Checkout the source somewhere on your filesystem with
 
-        git clone --recursive https://github.com/SMSSecure/SMSSecure.git
+        git clone --recursive https://github.com/SilenceIM/Silence.git
 
 2. Make sure you have the [Android SDK](https://developer.android.com/sdk/index.html) installed somewhere on your system.
 3. Ensure that the following packages are installed from the Android SDK manager:
@@ -44,8 +44,8 @@ Visual assets
 Sample command for generating our audio placeholder image:
 
 ```bash
-pngs_from_svg.py ic_audio.svg /path/to/SMSSecure/res/ 150 --color #000 --opacity 0.54 --suffix _light
-pngs_from_svg.py ic_audio.svg /path/to/SMSSecure/res/ 150 --color #fff --opacity 1.00 --suffix _light
+pngs_from_svg.py ic_audio.svg /path/to/Silence/res/ 150 --color #000 --opacity 0.54 --suffix _light
+pngs_from_svg.py ic_audio.svg /path/to/Silence/res/ 150 --color #fff --opacity 1.00 --suffix _light
 ```
 
 
@@ -89,7 +89,7 @@ Setting up a development environment
 2. Make sure the "Android Support Repository" is installed in the Android Studio SDK.
 3. Make sure the latest "Android SDK build-tools" is installed in the Android Studio SDK.
 4. Create a new Android Studio project. from the Quickstart pannel (use File > Close Project to see it), choose "Checkout from Version Control" then "git".
-5. Paste the URL for the SMSSecure project when prompted (https://github.com/SMSSecure/SMSSecure.git).
+5. Paste the URL for the Silence project when prompted (https://github.com/SilenceIM/Silence.git).
 6. Android studio should detect the presence of a project file and ask you whether to open it. Click "yes".
 7. Default config options should be good enough.
 8. Project initialisation and build should proceed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# SMSSecure Changelog
+# Silence Changelog
 
 ### [0.13.2] - 2016-02-07
 - Fixed keyboard/focus regressions
@@ -122,28 +122,28 @@
 - Changed app name
 - Removed non-free libraries
 
- [0.13.2]: https://github.com/SMSSecure/SMSSecure/compare/v0.13.1...v0.13.2
- [0.13.1]: https://github.com/SMSSecure/SMSSecure/compare/v0.13.0...v0.13.1
- [0.13.0]: https://github.com/SMSSecure/SMSSecure/compare/v0.12.3...v0.13.0
- [0.12.3]: https://github.com/SMSSecure/SMSSecure/compare/v0.12.1...v0.12.3
- [0.12.1]: https://github.com/SMSSecure/SMSSecure/compare/v0.11.3...v0.12.1
- [0.11.3]: https://github.com/SMSSecure/SMSSecure/compare/v0.11.1...v0.11.3
- [0.11.0]: https://github.com/SMSSecure/SMSSecure/compare/v0.10.1...v0.11.1
- [0.10.1]: https://github.com/SMSSecure/SMSSecure/compare/v0.9.0...v0.10.1
- [0.9.0]: https://github.com/SMSSecure/SMSSecure/compare/v0.8.1...v0.9.0
- [0.8.1]: https://github.com/SMSSecure/SMSSecure/compare/v0.8.0...v0.8.1
- [0.8.0]: https://github.com/SMSSecure/SMSSecure/compare/v0.7.0...v0.8.0
- [0.7.0]: https://github.com/SMSSecure/SMSSecure/compare/v0.6.0...v0.7.0
- [0.6.0]: https://github.com/SMSSecure/SMSSecure/compare/v0.5.4...v0.6.0
- [0.5.4]: https://github.com/SMSSecure/SMSSecure/compare/v0.5.3...v0.5.4
- [0.5.3]: https://github.com/SMSSecure/SMSSecure/compare/v0.5.2...v0.5.3
- [0.5.2]: https://github.com/SMSSecure/SMSSecure/compare/v0.5.1...v0.5.2
- [0.5.1]: https://github.com/SMSSecure/SMSSecure/compare/v0.4.2...v0.5.1
- [0.4.2]: https://github.com/SMSSecure/SMSSecure/compare/v0.4.1...v0.4.2
- [0.4.1]: https://github.com/SMSSecure/SMSSecure/compare/v0.4.0...v0.4.1
- [0.4.0]: https://github.com/SMSSecure/SMSSecure/compare/v0.3.3...v0.4.0
- [0.3.3]: https://github.com/SMSSecure/SMSSecure/compare/v0.3.2...v0.3.3
- [0.3.2]: https://github.com/SMSSecure/SMSSecure/compare/v0.3.1...v0.3.2
- [0.3.1]: https://github.com/SMSSecure/SMSSecure/compare/v0.3.0...v0.3.1
- [0.3.0]: https://github.com/SMSSecure/SMSSecure/compare/v0.2.0...v0.3.0
- [0.2.0]: https://github.com/SMSSecure/SMSSecure/compare/ac92fa6f5e1f86da833b38aa5955b685e1959846...v0.2.0
+ [0.13.2]: https://github.com/SilenceIM/Silence/compare/v0.13.1...v0.13.2
+ [0.13.1]: https://github.com/SilenceIM/Silence/compare/v0.13.0...v0.13.1
+ [0.13.0]: https://github.com/SilenceIM/Silence/compare/v0.12.3...v0.13.0
+ [0.12.3]: https://github.com/SilenceIM/Silence/compare/v0.12.1...v0.12.3
+ [0.12.1]: https://github.com/SilenceIM/Silence/compare/v0.11.3...v0.12.1
+ [0.11.3]: https://github.com/SilenceIM/Silence/compare/v0.11.1...v0.11.3
+ [0.11.0]: https://github.com/SilenceIM/Silence/compare/v0.10.1...v0.11.1
+ [0.10.1]: https://github.com/SilenceIM/Silence/compare/v0.9.0...v0.10.1
+ [0.9.0]: https://github.com/SilenceIM/Silence/compare/v0.8.1...v0.9.0
+ [0.8.1]: https://github.com/SilenceIM/Silence/compare/v0.8.0...v0.8.1
+ [0.8.0]: https://github.com/SilenceIM/Silence/compare/v0.7.0...v0.8.0
+ [0.7.0]: https://github.com/SilenceIM/Silence/compare/v0.6.0...v0.7.0
+ [0.6.0]: https://github.com/SilenceIM/Silence/compare/v0.5.4...v0.6.0
+ [0.5.4]: https://github.com/SilenceIM/Silence/compare/v0.5.3...v0.5.4
+ [0.5.3]: https://github.com/SilenceIM/Silence/compare/v0.5.2...v0.5.3
+ [0.5.2]: https://github.com/SilenceIM/Silence/compare/v0.5.1...v0.5.2
+ [0.5.1]: https://github.com/SilenceIM/Silence/compare/v0.4.2...v0.5.1
+ [0.4.2]: https://github.com/SilenceIM/Silence/compare/v0.4.1...v0.4.2
+ [0.4.1]: https://github.com/SilenceIM/Silence/compare/v0.4.0...v0.4.1
+ [0.4.0]: https://github.com/SilenceIM/Silence/compare/v0.3.3...v0.4.0
+ [0.3.3]: https://github.com/SilenceIM/Silence/compare/v0.3.2...v0.3.3
+ [0.3.2]: https://github.com/SilenceIM/Silence/compare/v0.3.1...v0.3.2
+ [0.3.1]: https://github.com/SilenceIM/Silence/compare/v0.3.0...v0.3.1
+ [0.3.0]: https://github.com/SilenceIM/Silence/compare/v0.2.0...v0.3.0
+ [0.2.0]: https://github.com/SilenceIM/Silence/compare/ac92fa6f5e1f86da833b38aa5955b685e1959846...v0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,12 @@ Please submit your corrections there.
 ## Submitting bug reports
 
 1. Search our issues first to make sure this is not a duplicate.
-2. (Optional) Search [TextSecure's issues](https://github.com/WhisperSystems/TextSecure/issues).
+2. (Optional) Search [Signal's issues](https://github.com/WhisperSystems/Signal-Android/issues).
 3. Open an issue with:
   * Device and app information
     * What's your device?
     * What Android version is it running?
-    * What version and build ID of SMSSecure do you have?
+    * What version and build ID of Silence do you have?
   * Upstream bug (if any)
   * App state
     * What are the relevant preferences that you have set that may be related to the issue?

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
-SMSSecure provides encrypted SMS messages for Android.
-https://github.com/SMSSecure/SMSSecure
-https://smssecure.org
+Silence (formerly SMSSecure) provides encrypted SMS messages for Android.
+https://github.com/SilenceIM/Silence
+https://silence.im
 
 
 Based on TextSecure v2.6.4 (March 12th, 2015)

--- a/README.md
+++ b/README.md
@@ -1,42 +1,42 @@
-# SMSSecure [![Build Status](https://travis-ci.org/SMSSecure/SMSSecure.svg?branch=master)](https://travis-ci.org/SMSSecure/SMSSecure)
+# Silence [![Build Status](https://travis-ci.org/SilenceIM/Silence.svg?branch=master)](https://travis-ci.org/SilenceIM/Silence)
 
-[SMSSecure](https://smssecure.org) is an SMS/MMS application that allows you to protect your privacy while communicating with friends.
+[Silence](https://silence.im) is an SMS/MMS application that allows you to protect your privacy while communicating with friends.
 
-Using SMSSecure, you can send SMS messages and share media or attachments with complete privacy.
+Using Silence, you can send SMS messages and share media or attachments with complete privacy.
 
 Features:
-* Easy. SMSSecure works like any other SMS application. There's nothing to sign up for and no new service your friends need to join.
-* Reliable. SMSSecure communicates using encrypted SMS messages. No servers or internet connection required.
-* Private. SMSSecure uses the TextSecure encryption protocol to provide privacy for every message, every time.
+* Easy. Silence works like any other SMS application. There's nothing to sign up for and no new service your friends need to join.
+* Reliable. Silence communicates using encrypted SMS messages. No servers or internet connection required.
+* Private. Silence uses the Axolotl encryption protocol to provide privacy for every message, every time.
 * Safe. All messages are encrypted locally, so if your phone is lost or stolen, your messages are protected.
-* Open Source. SMSSecure is Free and Open Source, enabling anyone to verify its security by auditing the code.
+* Open Source. Silence is Free and Open Source, enabling anyone to verify its security by auditing the code.
 
 
 ## Project goals
 
-This is a fork of [TextSecure](https://github.com/WhisperSystems/TextSecure) that aims to keep the SMS encryption that TextSecure removed [for a variety of reasons](https://whispersystems.org/blog/goodbye-encrypted-sms/).
+This is a fork of [TextSecure](https://github.com/WhisperSystems/TextSecure) (now Signal) that aims to keep the SMS encryption that TextSecure removed [for a variety of reasons](https://whispersystems.org/blog/goodbye-encrypted-sms/).
 
-SMSSecure focuses on SMS and MMS. This fork aims to:
+Silence focuses on SMS and MMS. This fork aims to:
 
 * Keep SMS/MMS encryption
-* Drop Google services dependencies (push messages are not available in SMSSecure)
+* Drop Google services dependencies (push messages are not available in Silence)
 * Integrate upstream bugfixes and patches from TextSecure
 
-## Migrating from TextSecure to SMSSecure
+## Migrating from TextSecure to Silence
 
 * In TextSecure, export a plaintext backup. Warning: the backup will **not** be encrypted.
-* Install SMSSecure.
-* In SMSSecure, import the plaintext backup (this will import the TextSecure backup if no SMSSecure backup is found).
+* Install Silence.
+* In Silence, import the plaintext backup (this will import the TextSecure backup if no Silence backup is found).
 * If TextSecure v2.6.4 or earlier is installed, update or uninstall it so it doesn't conflict (can cause errors with key exchanges).
-* Enjoy SMSSecure!
+* Enjoy Silence!
 
 Note: You will have to start new secured sessions with your contacts.
 
 # Contributing
 
-See [CONTRIBUTING.md](https://github.com/SMSSecure/SMSSecure/blob/master/CONTRIBUTING.md) for how to contribute code, translations, or bug reports.
+See [CONTRIBUTING.md](https://github.com/SilenceIM/Silence/blob/master/CONTRIBUTING.md) for how to contribute code, translations, or bug reports.
 
-Instructions on how to setup a development environment and build SMSSecure can be found in [BUILDING.md](https://github.com/SMSSecure/SMSSecure/blob/master/BUILDING.md).
+Instructions on how to setup a development environment and build Silence can be found in [BUILDING.md](https://github.com/SilenceIM/Silence/blob/master/BUILDING.md).
 
 # Help
 ## Documentation
@@ -45,7 +45,7 @@ Looking for documentation? Check out the wiki of the original project:
 https://github.com/WhisperSystems/TextSecure/wiki
 
 ## Chat
-Have a question? Want to help out? Join our IRC channel: [#SMSSecure on Freenode](https://webchat.freenode.net/?channels=SMSSecure) or follow [@SMSSecure_](https://twitter.com/SMSSecure_) on Twitter.
+Have a question? Want to help out? Join our IRC channel: [#Silence on Freenode](https://webchat.freenode.net/?channels=Silence) or follow [@SilenceIM](https://twitter.com/SilenceIM) on Twitter.
 
 # Legal
 ## Cryptography Notice

--- a/res/drawable-v21/conversation_list_item_read_background.xml
+++ b/res/drawable-v21/conversation_list_item_read_background.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-        android:color="@color/smssecure_primary">
+        android:color="@color/silence_primary">
     <item android:id="@android:id/mask" android:drawable="@android:color/black" />
     <item>
         <selector>
-            <item android:drawable="@color/smssecure_primary_alpha33" android:state_selected="true" />
+            <item android:drawable="@color/silence_primary_alpha33" android:state_selected="true" />
             <item android:drawable="@color/conversation_list_item_background_read_light" />
         </selector>
     </item>

--- a/res/drawable-v21/conversation_list_item_read_background_dark.xml
+++ b/res/drawable-v21/conversation_list_item_read_background_dark.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-        android:color="@color/smssecure_primary">
+        android:color="@color/silence_primary">
     <item android:id="@android:id/mask" android:drawable="@android:color/black" />
     <item>
         <selector>
-            <item android:drawable="@color/smssecure_primary_alpha33" android:state_selected="true" />
+            <item android:drawable="@color/silence_primary_alpha33" android:state_selected="true" />
             <item android:drawable="@color/conversation_list_item_background_read_dark" />
         </selector>
     </item>

--- a/res/drawable-v21/conversation_list_item_unread_background.xml
+++ b/res/drawable-v21/conversation_list_item_unread_background.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-        android:color="@color/smssecure_primary">
+        android:color="@color/silence_primary">
     <item android:id="@android:id/mask" android:drawable="@android:color/black" />
     <item>
         <selector>
-            <item android:drawable="@color/smssecure_primary_alpha33" android:state_selected="true" />
+            <item android:drawable="@color/silence_primary_alpha33" android:state_selected="true" />
             <item android:drawable="@color/conversation_list_item_background_unread_light" />
         </selector>
     </item>

--- a/res/drawable-v21/conversation_list_item_unread_background_dark.xml
+++ b/res/drawable-v21/conversation_list_item_unread_background_dark.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-        android:color="@color/smssecure_primary">
+        android:color="@color/silence_primary">
     <item android:id="@android:id/mask" android:drawable="@android:color/black" />
     <item>
         <selector>
-            <item android:drawable="@color/smssecure_primary_alpha33" android:state_selected="true" />
+            <item android:drawable="@color/silence_primary_alpha33" android:state_selected="true" />
             <item android:drawable="@color/conversation_list_item_background_unread_dark" />
         </selector>
     </item>

--- a/res/drawable/conversation_item_background.xml
+++ b/res/drawable/conversation_item_background.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/smssecure_primary_alpha33" android:state_selected="true" />
+    <item android:drawable="@color/silence_primary_alpha33" android:state_selected="true" />
 </selector>

--- a/res/drawable/conversation_list_item_read_background.xml
+++ b/res/drawable/conversation_list_item_read_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/smssecure_primary_alpha33" android:state_selected="true" />
-    <item android:drawable="@color/smssecure_primary_alpha33" android:state_pressed="true" />
+    <item android:drawable="@color/silence_primary_alpha33" android:state_selected="true" />
+    <item android:drawable="@color/silence_primary_alpha33" android:state_pressed="true" />
     <item android:drawable="@color/conversation_list_item_background_read_light" />
 </selector>

--- a/res/drawable/conversation_list_item_read_background_dark.xml
+++ b/res/drawable/conversation_list_item_read_background_dark.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/smssecure_primary_alpha33" android:state_selected="true" />
-    <item android:drawable="@color/smssecure_primary_alpha33" android:state_pressed="true" />
+    <item android:drawable="@color/silence_primary_alpha33" android:state_selected="true" />
+    <item android:drawable="@color/silence_primary_alpha33" android:state_pressed="true" />
     <item android:drawable="@color/conversation_list_item_background_read_dark" />
 </selector>

--- a/res/drawable/conversation_list_item_unread_background.xml
+++ b/res/drawable/conversation_list_item_unread_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/smssecure_primary_alpha33" android:state_selected="true" />
-    <item android:drawable="@color/smssecure_primary_alpha33" android:state_pressed="true" />
+    <item android:drawable="@color/silence_primary_alpha33" android:state_selected="true" />
+    <item android:drawable="@color/silence_primary_alpha33" android:state_pressed="true" />
     <item android:drawable="@color/conversation_list_item_background_unread_light" />
 </selector>

--- a/res/drawable/conversation_list_item_unread_background_dark.xml
+++ b/res/drawable/conversation_list_item_unread_background_dark.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/smssecure_primary_alpha33" android:state_selected="true" />
-    <item android:drawable="@color/smssecure_primary_alpha33" android:state_pressed="true" />
+    <item android:drawable="@color/silence_primary_alpha33" android:state_selected="true" />
+    <item android:drawable="@color/silence_primary_alpha33" android:state_pressed="true" />
     <item android:drawable="@color/conversation_list_item_background_unread_dark" />
 </selector>

--- a/res/layout/color_fragment.xml
+++ b/res/layout/color_fragment.xml
@@ -43,7 +43,7 @@
               android:paddingLeft="20dp"
               android:paddingRight="20dp"
               android:fontFamily="sans-serif-light"
-              tools:text="@string/IntroScreenActivity_smssecure_description"
+              tools:text="@string/IntroScreenActivity_silence_description"
               android:textColor="@android:color/white" />
 
 </LinearLayout>

--- a/res/layout/contact_selection_activity.xml
+++ b/res/layout/contact_selection_activity.xml
@@ -38,7 +38,7 @@
                           android:layout_marginLeft="5dp"
                           android:hint="@string/contact_selection_activity__enter_name_or_number"
                           android:inputType="textPersonName"
-                          style="@style/SMSSecure.TitleTextStyle"
+                          style="@style/Silence.TitleTextStyle"
                           android:background="@android:color/transparent"
                           android:layout_gravity="center_vertical"
                           android:gravity="center_vertical"/>

--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -94,7 +94,7 @@
                         android:layout_weight="1"
                         android:nextFocusForward="@+id/send_button"
                         android:nextFocusRight="@+id/send_button"
-                        tools:hint="Send SMSSecure message">
+                        tools:hint="Send Silence message">
                     <requestFocus />
                 </org.smssecure.smssecure.components.ComposeText>
             </LinearLayout>

--- a/res/layout/conversation_title_view.xml
+++ b/res/layout/conversation_title_view.xml
@@ -18,7 +18,7 @@
               android:drawablePadding="5dp"
               android:gravity="center_vertical"
               android:layout_gravity="center_vertical"
-              style="@style/SMSSecure.TitleTextStyle"
+              style="@style/Silence.TitleTextStyle"
               tools:ignore="UnusedAttribute"/>
 
     <TextView android:id="@+id/subtitle"
@@ -29,6 +29,6 @@
               android:layout_gravity="center_vertical|start"
               android:gravity="center_vertical"
               android:textDirection="ltr"
-              style="@style/SMSSecure.SubtitleTextStyle"/>
+              style="@style/Silence.SubtitleTextStyle"/>
 
 </org.smssecure.smssecure.ConversationTitleView>

--- a/res/layout/outgoing_sms_preference.xml
+++ b/res/layout/outgoing_sms_preference.xml
@@ -9,7 +9,7 @@
     android:paddingRight="10dp">
 
     <CheckBox android:id="@+id/data_users"
-        style="@style/SMSSecureDialogPrimaryText"
+        style="@style/SilenceDialogPrimaryText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:checkMark="?android:attr/listChoiceIndicatorMultiple"
@@ -17,7 +17,7 @@
         android:text="" />
 
     <TextView
-        style="@style/SMSSecureDialogSecondaryText"
+        style="@style/SilenceDialogSecondaryText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="-5dp"
@@ -26,7 +26,7 @@
         android:text="" />
 
     <CheckBox android:id="@+id/ask_before_fallback_data"
-        style="@style/SMSSecureDialogPrimaryText"
+        style="@style/SilenceDialogPrimaryText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textSize="14sp"
@@ -35,7 +35,7 @@
         android:layout_marginLeft="25dp" />
 
     <CheckBox android:id="@+id/never_send_mms"
-              style="@style/SMSSecureDialogPrimaryText"
+              style="@style/SilenceDialogPrimaryText"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:textSize="14sp"
@@ -44,7 +44,7 @@
               android:layout_marginLeft="25dp" />
 
     <CheckBox android:id="@+id/non_data_users"
-        style="@style/SMSSecureDialogPrimaryText"
+        style="@style/SilenceDialogPrimaryText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:checkMark="?android:attr/listChoiceIndicatorMultiple"

--- a/res/layout/prompt_apn_activity.xml
+++ b/res/layout/prompt_apn_activity.xml
@@ -23,7 +23,7 @@
                       android:layout_width="fill_parent"
                       android:layout_height="wrap_content"
                       android:layout_marginBottom="16dip"
-                      android:text="@string/prompt_mms_activity__textsecure_requires_mms_settings_to_deliver_media_and_group_messages"/>
+                      android:text="@string/prompt_mms_activity__silence_requires_mms_settings_to_deliver_media_and_group_messages"/>
                     
             <TextView style="@style/Registration.Description"
                       android:layout_width="fill_parent"

--- a/res/layout/recipient_preference_activity.xml
+++ b/res/layout/recipient_preference_activity.xml
@@ -12,7 +12,7 @@
             android:layout_width="match_parent"
             android:minHeight="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
-            android:theme="@style/SMSSecure.LightActionBar">
+            android:theme="@style/Silence.LightActionBar">
 
         <LinearLayout android:layout_width="match_parent"
                       android:layout_height="match_parent"
@@ -38,7 +38,7 @@
                           android:layout_height="wrap_content"
                           android:ellipsize="end"
                           android:transitionName="recipient_name"
-                          style="@style/SMSSecure.TitleTextStyle"
+                          style="@style/Silence.TitleTextStyle"
                           tools:ignore="UnusedAttribute" />
 
                 <TextView android:id="@+id/blocked_indicator"

--- a/res/layout/transport_selection_list_item.xml
+++ b/res/layout/transport_selection_list_item.xml
@@ -16,7 +16,7 @@
                android:background="@drawable/circle_tintable"
                android:contentDescription="@string/transport_selection_list_item__transport_icon"
                tools:src="@drawable/ic_send_secure_white_24dp"
-               tools:backgroundTint="@color/smssecure_primary" />
+               tools:backgroundTint="@color/silence_primary" />
 
     <LinearLayout android:orientation="vertical"
                   android:layout_width="match_parent"

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <resources>
-    <color name="smssecure_primary">#ff2090ea</color>
-    <color name="smssecure_primary_dark">#ff1c7ac5</color>
-    <color name="smssecure_primary_alpha33">#552090ea</color>
+    <color name="silence_primary">#ff2090ea</color>
+    <color name="silence_primary_dark">#ff1c7ac5</color>
+    <color name="silence_primary_alpha33">#552090ea</color>
 
     <color name="white">#ffffffff</color>
     <color name="black">#ff000000</color>

--- a/res/values/distribution-strings.xml
+++ b/res/values/distribution-strings.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    These strings are used as the SMSSecure description on various distribution channels.
+    These strings are used as the Silence description on various distribution channels.
 
     To translate these strings see the "Contributing Translations" portion of the README
 
@@ -10,28 +10,28 @@
 
 <resources>
 
-    <string name="Distribution_title">SMSSecure</string>
+    <string name="Distribution_title">Silence</string>
     <string name="Distribution_tagline">Encrypted SMS/MMS conversations made easy!</string>
-    <string name="Distribution_description">SMSSecure is an SMS/MMS application that allows you to protect your privacy while communicating with friends.</string>
+    <string name="Distribution_description">Silence is an SMS/MMS application that allows you to protect your privacy while communicating with friends.</string>
     <string name="Distribution_long_description">
-        SMSSecure is an SMS/MMS application that allows you to protect your privacy while communicating with friends.
-        Using SMSSecure, you can send SMS messages and share media or attachments with complete privacy.
+        Silence is an SMS/MMS application that allows you to protect your privacy while communicating with friends.
+        Using Silence, you can send SMS messages and share media or attachments with complete privacy.
 
         Features:
-        * Easy. SMSSecure works like any other SMS application. There\'s nothing to sign up for and no new service your friends need to join.
-        * Reliable. SMSSecure communicates using encrypted SMS messages. No servers or internet connection required.
-        * Private. SMSSecure provides end-to-end encryption for your messages using the painstakingly engineered TextSecure encryption protocol.
+        * Easy. Silence works like any other SMS application. There\'s nothing to sign up for and no new service your friends need to join.
+        * Reliable. Silence communicates using encrypted SMS messages. No servers or internet connection required.
+        * Private. Silence provides end-to-end encryption for your messages using the painstakingly engineered TextSecure encryption protocol.
         * Safe. All messages are encrypted locally, so if your phone is lost or stolen, your messages are protected.
-        * Open Source. SMSSecure is Free and Open Source, enabling anyone to verify its security by auditing the code.
+        * Open Source. Silence is Free and Open Source, enabling anyone to verify its security by auditing the code.
 
         Please file any bugs, issues, or feature requests at:
-        https://github.com/SMSSecure/SMSSecure/issues
+        https://github.com/SilenceIM/Silence/issues
 
         The source code can be found at:
-        https://github.com/SMSSecure/SMSSecure
+        https://github.com/SilenceIM/Silence
 
         More details:
-        http://smssecure.org
+        https://silence.im
     </string>
 
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">SMSSecure</string>
+    <string name="app_name">Silence</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="delete">Delete</string>
@@ -28,7 +28,7 @@
     <string name="ApplicationPreferencesActivity_sms_enabled">Incoming SMS enabled</string>
     <string name="ApplicationPreferencesActivity_touch_to_change_your_default_sms_app">Touch to change your default SMS app</string>
     <string name="ApplicationPreferencesActivity_sms_disabled">Incoming SMS disabled</string>
-    <string name="ApplicationPreferencesActivity_touch_to_make_textsecure_your_default_sms_app">Touch to make SMSSecure your default SMS app</string>
+    <string name="ApplicationPreferencesActivity_touch_to_make_silence_your_default_sms_app">Touch to make Silence your default SMS app</string>
     <string name="ApplicationPreferencesActivity_on">on</string>
     <string name="ApplicationPreferencesActivity_On">On</string>
     <string name="ApplicationPreferencesActivity_off">off</string>
@@ -84,7 +84,7 @@
     <!-- ConversationActivity -->
     <string name="ConversationActivity_initiate_secure_session_question">Initiate secure session?</string>
     <string name="ConversationActivity_initiate_secure_session_with_s_question">Initiate secure session with %s?</string>
-    <string name="ConversationActivity_detected_smssecure_initiate_session_question">Message received from someone who also has SMSSecure, initiate a secure encrypted session?</string>
+    <string name="ConversationActivity_detected_silence_initiate_session_question">Message received from someone who also has Silence, initiate a secure encrypted session?</string>
     <string name="ConversationActivity_abort_secure_session_confirmation">End secure session?</string>
     <string name="ConversationActivity_are_you_sure_that_you_want_to_abort_this_secure_session_question">Are you sure you want to end this secure session?</string>
     <string name="ConversationActivity_delete_thread_question">Delete conversation?</string>
@@ -199,17 +199,19 @@
     <string name="ShareActivity_share_with">Share with</string>
 
     <!-- IntroScreenActivity -->
-    <string name="IntroScreenActivity_welcome_to_smssecure">Welcome to SMSSecure!</string>
-    <string name="IntroScreenActivity_smssecure_description">SMSSecure allows you to protect your privacy while communicating with friends.</string>
+    <string name="IntroScreenActivity_welcome_to_silence">Welcome to Silence!</string>
+    <string name="IntroScreenActivity_silence_description">Silence allows you to protect your privacy while communicating with friends.</string>
     <string name="IntroScreenActivity_encrypt_your_messages">Encrypt your messages</string>
-    <string name="IntroScreenActivity_encrypt_your_messages_description">SMSSecure will encrypt messages with other SMSSecure users automatically.</string>
+    <string name="IntroScreenActivity_encrypt_your_messages_description">Silence will encrypt messages with other Silence users automatically.</string>
     <string name="IntroScreenActivity_talk_to_everyone">Talk to everyone</string>
-    <string name="IntroScreenActivity_talk_to_everyone_description">SMSSecure can use unencrypted messages to chat with non-SMSSecure users.</string>
+    <string name="IntroScreenActivity_talk_to_everyone_description">Silence can use unencrypted messages to chat with non-Silence users.</string>
+    <string name="IntroScreenActivity_smssecure_is_now_silence">SMSSecure is now Silence.</string>
+    <string name="IntroScreenActivity_your_messages_are_still_here">SMSSecure is now Silence. Your messages are still here and new features are coming.</string>
 
     <!-- ExportFragment -->
     <string name="ExportFragment_export">Export</string>
     <string name="ExportFragment_export_plaintext_to_storage">Export plaintext to storage?</string>
-    <string name="ExportFragment_warning_this_will_export_the_plaintext_contents">Warning, this will export the plaintext contents of your SMSSecure messages to storage.</string>
+    <string name="ExportFragment_warning_this_will_export_the_plaintext_contents">Warning, this will export the plaintext contents of your Silence messages to storage.</string>
     <string name="ExportFragment_cancel">Cancel</string>
     <string name="ExportFragment_exporting">Exporting</string>
     <string name="ExportFragment_exporting_plaintext_to_storage">Exporting plaintext to storage...</string>
@@ -238,13 +240,13 @@
     <!-- ImportFragment -->
     <string name="ImportFragment_import_system_sms_database">Import system SMS database?</string>
     <string name="ImportFragment_this_will_import_messages_from_the_system">This will import
-        messages from the system\'s default SMS database to SMSSecure. If you\'ve imported
+        messages from the system\'s default SMS database to Silence. If you\'ve imported
         the system\'s SMS database before, importing again will result in duplicated messages.
     </string>
     <string name="ImportFragment_import">Import</string>
     <string name="ImportFragment_cancel">Cancel</string>
     <string name="ImportFragment_import_encrypted_backup">Import encrypted backup?</string>
-    <string name="ImportFragment_importing_an_encrypted_backup_will_completely_replace_your_existing_keys">Importing an encrypted backup will completely replace your existing keys, preferences, and messages. You will lose any information that\'s in your current SMSSecure installation but not in the backup. SMSSecure will stop after the import.</string>
+    <string name="ImportFragment_importing_an_encrypted_backup_will_completely_replace_your_existing_keys">Importing an encrypted backup will completely replace your existing keys, preferences, and messages. You will lose any information that\'s in your current Silence installation but not in the backup. Silence will stop after the import.</string>
     <string name="ImportFragment_import_plaintext_backup">Import plaintext backup?</string>
     <string name="ImportFragment_this_will_import_messages_from_a_plaintext_backup">This will import
         messages from a plaintext backup. If you\'ve previously imported this backup,
@@ -261,7 +263,7 @@
     <!-- KeyScanningActivity -->
     <string name="KeyScanningActivity_no_scanned_key_found_exclamation">No scanned key found!</string>
     <string name="KeyScanningActivity_install_barcode_Scanner">Install Barcode Scanner?</string>
-    <string name="KeyScanningActivity_this_application_requires_barcode_scanner_would_you_like_to_install_it">SMSSecure needs Barcode Scanner for QR codes.</string>
+    <string name="KeyScanningActivity_this_application_requires_barcode_scanner_would_you_like_to_install_it">Silence needs Barcode Scanner for QR codes.</string>
 
     <!-- MessageDetailsRecipient -->
     <string name="MessageDetailsRecipient_failed_to_send">Failed to send</string>
@@ -276,7 +278,7 @@
     <string name="NotificationMmsMessageRecord_multimedia_message">Multimedia message</string>
 
     <!-- MessageRecord -->
-    <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Received a message encrypted using an old version of SMSSecure that is no longer supported. Please ask the sender to upgrade to the most recent version and resend the message.</string>
+    <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Received a message encrypted using an old version of Silence that is no longer supported. Please ask the sender to upgrade to the most recent version and resend the message.</string>
     <string name="MessageRecord_left_group">You have left the group.</string>
     <string name="MessageRecord_updated_group">Updated the group.</string>
 
@@ -287,14 +289,14 @@
 
     <!-- PassphrasePromptActivity -->
     <string name="PassphrasePromptActivity_enter_passphrase">Enter passphrase</string>
-    <string name="PassphrasePromptActivity_watermark_content_description">SMSSecure icon</string>
+    <string name="PassphrasePromptActivity_watermark_content_description">Silence icon</string>
     <string name="PassphrasePromptActivity_invalid_passphrase_exclamation">Invalid passphrase!</string>
 
     <!-- ReceiveKeyActivity -->
     <string name="ReceiveKeyActivity_the_signature_on_this_key_exchange_is_different">The
         signature on this key exchange is different than what you\'ve previously received from this
         contact. This could either mean that someone is trying to intercept your communication, or
-        that this contact simply re-installed SMSSecure and now has a new identity key.
+        that this contact simply re-installed Silence and now has a new identity key.
     </string>
     <string name="ReceiveKeyActivity_the_signature_on_this_key_exchange_is_trusted_but">The
         signature on this key exchange is trusted, but you have the \'automatically complete key
@@ -392,7 +394,7 @@
     <!-- KeyCachingService -->
     <string name="KeyCachingService_textsecure_passphrase_cached">Touch to open.</string>
     <string name="KeyCachingService_textsecure_passphrase_cached_with_lock">Touch to open, or touch the lock to close.</string>
-    <string name="KeyCachingService_passphrase_cached">SMSSecure is unlocked</string>
+    <string name="KeyCachingService_passphrase_cached">Silence is unlocked</string>
     <string name="KeyCachingService_lock">Lock with passphrase</string>
 
     <!-- MessageNotifier -->
@@ -411,11 +413,11 @@
     <string name="MessageNotifier_reply">Reply</string>
 
     <!-- QuickResponseService -->
-    <string name="QuickResponseService_quick_response_unavailable_when_SMSSecure_is_locked">Quick response unavailable when SMSSecure is locked!</string>
+    <string name="QuickResponseService_quick_response_unavailable_when_Silence_is_locked">Quick response unavailable when Silence is locked!</string>
     <string name="QuickResponseService_problem_sending_message">Problem sending message!</string>
 
     <!-- SingleRecipientNotificationBuilder -->
-    <string name="SingleRecipientNotificationBuilder_smssecure">SMSSecure</string>
+    <string name="SingleRecipientNotificationBuilder_silence">Silence</string>
     <string name="SingleRecipientNotificationBuilder_new_message">New message</string>
 
     <!-- change_passphrase_activity -->
@@ -486,7 +488,7 @@
     <string name="log_submit_activity__posting_logs">Posting the logs to gist...</string>
 
     <!-- database_migration_activity -->
-    <string name="database_migration_activity__would_you_like_to_import_your_existing_text_messages">Would you like to import your existing text messages into SMSSecure\'s encrypted database?</string>
+    <string name="database_migration_activity__would_you_like_to_import_your_existing_text_messages">Would you like to import your existing text messages into Silence\'s encrypted database?</string>
     <string name="database_migration_activity__the_default_system_database_will_not_be_modified">The default system database will not be modified or altered in any way.</string>
     <string name="database_migration_activity__skip">Skip</string>
     <string name="database_migration_activity__import">Import</string>
@@ -521,7 +523,7 @@
     <string name="prompt_passphrase_activity__unlock">Unlock</string>
 
     <!-- prompt_mms_activity -->
-    <string name="prompt_mms_activity__textsecure_requires_mms_settings_to_deliver_media_and_group_messages">SMSSecure requires MMS settings to deliver media and group messages through your wireless carrier. Your device does not make this information available, which is occasionally true for locked devices and other restrictive configurations.</string>
+    <string name="prompt_mms_activity__silence_requires_mms_settings_to_deliver_media_and_group_messages">Silence requires MMS settings to deliver media and group messages through your wireless carrier. Your device does not make this information available, which is occasionally true for locked devices and other restrictive configurations.</string>
     <string name="prompt_mms_activity__to_send_media_and_group_messages_tap_ok">To send media and group messages, tap \'OK\' and complete the requested settings. The MMS settings for your carrier can generally be located by searching for \'your carrier APN\'. You will only need to do this once.</string>
 
     <!-- recipient_preferences_activity -->
@@ -606,8 +608,8 @@
     <string name="preferences__sms_mms">SMS and MMS</string>
     <string name="preferences__pref_all_sms_title">Receive all SMS</string>
     <string name="preferences__pref_all_mms_title">Receive all MMS</string>
-    <string name="preferences__use_textsecure_for_viewing_and_storing_all_incoming_text_messages">Use SMSSecure for viewing and storing all incoming text messages</string>
-    <string name="preferences__use_textsecure_for_viewing_and_storing_all_incoming_multimedia_messages">Use SMSSecure for viewing and storing all incoming multimedia messages</string>
+    <string name="preferences__use_silence_for_viewing_and_storing_all_incoming_text_messages">Use Silence for viewing and storing all incoming text messages</string>
+    <string name="preferences__use_silence_for_viewing_and_storing_all_incoming_multimedia_messages">Use Silence for viewing and storing all incoming multimedia messages</string>
     <string name="preferences__keyboard_settings">Keyboard options</string>
     <string name="preferences__disable_emoji_drawer">Disable Emoji drawer</string>
     <string name="preferences__enable_this_option_if_your_keyboard_supports_emojis">Enable this option if your keyboard supports Emojis.</string>
@@ -691,11 +693,11 @@
     <string name="preferences__default">Default</string>
     <string name="preferences__language">Language</string>
     <string name="preferences__make_default_sms_app">Set as default SMS app</string>
-    <string name="preferences__make_textsecure_the_default_sms_mms_app">Make SMSSecure the default SMS/MMS application for your system.</string>
+    <string name="preferences__make_silence_the_default_sms_mms_app">Make Silence the default SMS/MMS application for your system.</string>
     <string name="preferences__submit_debug_log">Submit debug log</string>
     <string name="preferences__support_wifi_calling">\'WiFi Calling\' compatibility mode</string>
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device).</string>
-    <string name="preferences__about">About SMSSecure</string>
+    <string name="preferences__about">About Silence</string>
     <string name="preferences__about_version">Version %s</string>
     <string name="preferences__about_build_id">Build ID: %s</string>
     <string name="preferences_app_protection__blocked_contacts">Blocked contacts</string>
@@ -813,7 +815,7 @@
 
     <!-- reminder_header -->
     <string name="reminder_header_sms_default_title">Use as default SMS app?</string>
-    <string name="reminder_header_sms_default_text">Tap to make SMSSecure your default SMS app.</string>
+    <string name="reminder_header_sms_default_text">Tap to make Silence your default SMS app.</string>
     <string name="reminder_header_sms_default_button">SET</string>
     <string name="reminder_header_sms_import_title">Import system SMS?</string>
     <string name="reminder_header_sms_import_text">Tap to copy your phone\'s SMS messages into its encrypted database.</string>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -9,7 +9,7 @@
         <item name="android:windowAnimationStyle">@null</item>
     </style>
 
-    <style name="SMSSecure.DialogActivity" parent="Theme.AppCompat.Light">
+    <style name="Silence.DialogActivity" parent="Theme.AppCompat.Light">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowContentOverlay">@null</item>
@@ -19,14 +19,14 @@
     </style>
 
     <style name="AppCompatAlertDialogStyle" parent="Theme.AppCompat.Light.Dialog.Alert">
-        <item name="colorAccent">@color/smssecure_primary_dark</item>
-        <item name="colorPrimary">@color/smssecure_primary</item>
-        <item name="colorPrimaryDark">@color/smssecure_primary_dark</item>
-        <item name="android:textColorLink">@color/smssecure_primary_dark</item>
+        <item name="colorAccent">@color/silence_primary_dark</item>
+        <item name="colorPrimary">@color/silence_primary</item>
+        <item name="colorPrimaryDark">@color/silence_primary_dark</item>
+        <item name="android:textColorLink">@color/silence_primary_dark</item>
     </style>
 
     <!-- ActionBar styles -->
-    <style name="SMSSecure.DarkActionBar"
+    <style name="Silence.DarkActionBar"
            parent="@style/Widget.AppCompat.ActionBar">
         <item name="android:icon">@drawable/actionbar_icon</item>
         <item name="icon">@drawable/actionbar_icon</item>
@@ -34,48 +34,48 @@
         <item name="logo">@drawable/actionbar_icon</item>
         <item name="android:popupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="popupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
-        <item name="titleTextStyle">@style/SMSSecure.TitleTextStyle</item>
-        <item name="subtitleTextStyle">@style/SMSSecure.SubtitleTextStyle</item>
+        <item name="titleTextStyle">@style/Silence.TitleTextStyle</item>
+        <item name="subtitleTextStyle">@style/Silence.SubtitleTextStyle</item>
     </style>
 
-    <style name="SMSSecure.LightActionBar"
+    <style name="Silence.LightActionBar"
            parent="@style/Widget.AppCompat.ActionBar">
-        <item name="background">@color/smssecure_primary</item>
+        <item name="background">@color/silence_primary</item>
         <item name="elevation">2dp</item>
         <item name="logo">@drawable/actionbar_icon</item>
         <item name="icon">@drawable/actionbar_icon</item>
         <item name="popupTheme">@style/ThemeOverlay.AppCompat.Light</item>
-        <item name="titleTextStyle">@style/SMSSecure.TitleTextStyle</item>
-        <item name="subtitleTextStyle">@style/SMSSecure.SubtitleTextStyle</item>
+        <item name="titleTextStyle">@style/Silence.TitleTextStyle</item>
+        <item name="subtitleTextStyle">@style/Silence.SubtitleTextStyle</item>
         <item name="android:textColorPrimary">@color/white</item>
         <item name="android:textColorSecondary">#BFffffff</item>
     </style>
 
-    <style name="SMSSecure.DarkActionBar.TabBar"
+    <style name="Silence.DarkActionBar.TabBar"
         parent="@style/Widget.AppCompat.ActionBar.TabBar">
         <item name="background">@color/gray95</item>
         <item name="android:background">@color/gray95</item>
     </style>
 
-    <style name="SMSSecure.LightActionBar.TabBar"
+    <style name="Silence.LightActionBar.TabBar"
         parent="@style/Widget.AppCompat.ActionBar.TabBar">
-        <item name="android:background">@color/smssecure_primary</item>
-        <item name="background">@color/smssecure_primary</item>
+        <item name="android:background">@color/silence_primary</item>
+        <item name="background">@color/silence_primary</item>
     </style>
 
-    <style name="SMSSecure.TitleTextStyle" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
+    <style name="Silence.TitleTextStyle" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
         <item name="android:textColor">@color/white</item>
         <item name="android:textColorHint">#BFffffff</item>
     </style>
 
-    <style name="SMSSecure.SubtitleTextStyle" parent="TextAppearance.AppCompat.Widget.ActionBar.Subtitle">
+    <style name="Silence.SubtitleTextStyle" parent="TextAppearance.AppCompat.Widget.ActionBar.Subtitle">
         <item name="android:textColor">#BFffffff</item>
     </style>
 
-    <style name="SMSSecure.IntroActionBar" parent="Widget.AppCompat.Light.ActionBar.Solid.Inverse">
+    <style name="Silence.IntroActionBar" parent="Widget.AppCompat.Light.ActionBar.Solid.Inverse">
         <item name="background">@null</item>
         <item name="icon">@android:color/transparent</item>
-        <item name="colorButtonNormal">@color/smssecure_primary</item>
+        <item name="colorButtonNormal">@color/silence_primary</item>
     </style>
 
     <style name="transparent_progress">
@@ -143,29 +143,29 @@
     </style>
 
     <!-- For Holo Light Dialog Activity Styling Emulation -->
-    <style name="SMSSecureDialogWindowTitle">
+    <style name="SilenceDialogWindowTitle">
         <item name="android:textSize">22sp</item>
         <item name="android:textColor">@color/textsecure_holo_blue_light</item>
     </style>
 
-    <style name="SMSSecureDialogButtonBar"
+    <style name="SilenceDialogButtonBar"
            tools:ignore="NewApi">
         <item name="android:background">@null</item>
         <item name="android:dividerPadding">0dp</item>
     </style>
 
-    <style name="SMSSecureBorderlessButtonSmall">
+    <style name="SilenceBorderlessButtonSmall">
         <item name="android:textSize">14sp</item>
     </style>
 
     <style name="Widget.ProgressBar.Horizontal" parent="@android:style/Widget.ProgressBar.Horizontal">
     </style>
 
-    <style name="SMSSecureDialogPrimaryText">
+    <style name="SilenceDialogPrimaryText">
         <item name="android:textColor">@color/white</item>
     </style>
 
-    <style name="SMSSecureDialogSecondaryText">
+    <style name="SilenceDialogSecondaryText">
         <item name="android:textColor">#ff999999</item>
     </style>
 

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -2,25 +2,25 @@
 
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="SMSSecure.LightNoActionBar" parent="@style/Theme.AppCompat.Light.NoActionBar">
+    <style name="Silence.LightNoActionBar" parent="@style/Theme.AppCompat.Light.NoActionBar">
         <item name="theme_type">light</item>
-        <item name="actionBarStyle">@style/SMSSecure.LightActionBar</item>
-        <item name="actionBarTabBarStyle">@style/SMSSecure.LightActionBar.TabBar</item>
-        <item name="colorPrimary">@color/smssecure_primary</item>
-        <item name="colorPrimaryDark">@color/smssecure_primary_dark</item>
-        <item name="colorAccent">@color/smssecure_primary_dark</item>
+        <item name="actionBarStyle">@style/Silence.LightActionBar</item>
+        <item name="actionBarTabBarStyle">@style/Silence.LightActionBar.TabBar</item>
+        <item name="colorPrimary">@color/silence_primary</item>
+        <item name="colorPrimaryDark">@color/silence_primary_dark</item>
+        <item name="colorAccent">@color/silence_primary_dark</item>
 
         <item name="recipient_preference_blocked">#d00000</item>
         <item name="contact_selection_label_text">#66000000</item>
         <item name="contact_selection_push_user">#ff000000</item>
         <item name="contact_selection_lay_user">#a0000000</item>
-        <item name="contact_selection_header_text">@color/smssecure_primary_dark</item>
+        <item name="contact_selection_header_text">@color/silence_primary_dark</item>
     </style>
 
-    <style name="SMSSecure.DarkNoActionBar" parent="@style/Theme.AppCompat.NoActionBar">
+    <style name="Silence.DarkNoActionBar" parent="@style/Theme.AppCompat.NoActionBar">
         <item name="theme_type">dark</item>
-        <item name="actionBarStyle">@style/SMSSecure.DarkActionBar</item>
-        <item name="actionBarTabBarStyle">@style/SMSSecure.DarkActionBar.TabBar</item>
+        <item name="actionBarStyle">@style/Silence.DarkActionBar</item>
+        <item name="actionBarTabBarStyle">@style/Silence.DarkActionBar.TabBar</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
 
         <item name="recipient_preference_blocked">#d00000</item>
@@ -30,9 +30,9 @@
         <item name="contact_selection_header_text">#66eeeeee</item>
     </style>
 
-    <style name="SMSSecure.LightIntroTheme" parent="@style/Theme.AppCompat.Light">
+    <style name="Silence.LightIntroTheme" parent="@style/Theme.AppCompat.Light">
         <!--<item name="colorPrimary">@android:color/transparent</item>-->
-        <item name="actionBarStyle">@style/SMSSecure.IntroActionBar</item>
+        <item name="actionBarStyle">@style/Silence.IntroActionBar</item>
         <item name="android:windowContentOverlay">@null</item>
 
         <item name="android:textColorHint">#cc000000</item>
@@ -43,8 +43,8 @@
         <item name="ic_visibility_off">@drawable/ic_visibility_off_grey600_24dp</item>
     </style>
 
-    <style name="SMSSecure.DarkIntroTheme" parent="@style/Theme.AppCompat">
-        <item name="actionBarStyle">@style/SMSSecure.IntroActionBar</item>
+    <style name="Silence.DarkIntroTheme" parent="@style/Theme.AppCompat">
+        <item name="actionBarStyle">@style/Silence.IntroActionBar</item>
         <item name="android:windowContentOverlay">@null</item>
 
         <item name="android:textColorHint">@color/white</item>
@@ -61,7 +61,7 @@
         <item name="android:windowExitAnimation">@anim/slide_to_top</item>
     </style>
 
-    <style name="SMSSecure.LightTheme.Popup" parent="SMSSecure.LightTheme">
+    <style name="Silence.LightTheme.Popup" parent="Silence.LightTheme">
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowSoftInputMode">stateUnchanged</item>
         <item name="android:windowContentOverlay">@null</item>
@@ -73,15 +73,15 @@
         <item name="android:backgroundDimEnabled">false</item>
     </style>
 
-    <style name="SMSSecure.LightTheme" parent="@style/Theme.AppCompat.Light.DarkActionBar">
+    <style name="Silence.LightTheme" parent="@style/Theme.AppCompat.Light.DarkActionBar">
         <item name="theme_type">light</item>
-        <item name="actionBarStyle">@style/SMSSecure.LightActionBar</item>
-        <item name="actionBarTabBarStyle">@style/SMSSecure.LightActionBar.TabBar</item>
-        <item name="colorPrimary">@color/smssecure_primary</item>
-        <item name="colorPrimaryDark">@color/smssecure_primary_dark</item>
-        <item name="colorAccent">@color/smssecure_primary_dark</item>
-        <item name="colorControlActivated">@color/smssecure_primary</item>
-        <item name="colorControlHighlight">@color/smssecure_primary</item>
+        <item name="actionBarStyle">@style/Silence.LightActionBar</item>
+        <item name="actionBarTabBarStyle">@style/Silence.LightActionBar.TabBar</item>
+        <item name="colorPrimary">@color/silence_primary</item>
+        <item name="colorPrimaryDark">@color/silence_primary_dark</item>
+        <item name="colorAccent">@color/silence_primary_dark</item>
+        <item name="colorControlActivated">@color/silence_primary</item>
+        <item name="colorControlHighlight">@color/silence_primary</item>
         <item name="android:windowBackground">@color/gray5</item>
         <item name="alertDialogTheme">@style/AppCompatAlertDialogStyle</item>
         <!--<item name="android:windowContentOverlay">@drawable/compat_actionbar_shadow_background</item>-->
@@ -96,7 +96,7 @@
 
         <item name="share_list_item_divider">@drawable/share_list_divider_shape</item>
 
-        <item name="fab_color">@color/smssecure_primary</item>
+        <item name="fab_color">@color/silence_primary</item>
         <item name="lower_right_divet">@drawable/divet_lower_right_dark</item>
 
         <item name="conversation_group_member_name">#99000000</item>
@@ -188,16 +188,16 @@
         <item name="group_members_dialog_icon">@drawable/ic_group_grey600_24dp</item>
     </style>
 
-    <style name="SMSSecure.DarkTheme" parent="@style/Theme.AppCompat">
+    <style name="Silence.DarkTheme" parent="@style/Theme.AppCompat">
         <item name="theme_type">dark</item>
-        <item name="actionBarStyle">@style/SMSSecure.DarkActionBar</item>
-        <item name="actionBarTabBarStyle">@style/SMSSecure.DarkActionBar.TabBar</item>
+        <item name="actionBarStyle">@style/Silence.DarkActionBar</item>
+        <item name="actionBarTabBarStyle">@style/Silence.DarkActionBar.TabBar</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="android:textColor">@color/text_color_dark_theme</item>
         <item name="android:textColorSecondary">@color/text_color_secondary_dark_theme</item>
-        <item name="colorAccent">@color/smssecure_primary_dark</item>
-        <item name="colorControlActivated">@color/smssecure_primary_dark</item>
-        <item name="colorControlHighlight">@color/smssecure_primary_dark</item>
+        <item name="colorAccent">@color/silence_primary_dark</item>
+        <item name="colorControlActivated">@color/silence_primary_dark</item>
+        <item name="colorControlHighlight">@color/silence_primary_dark</item>
         <item name="android:windowBackground">@color/black</item>
         <item name="conversation_list_item_background_selected">@drawable/list_selected_holo_dark</item>
         <item name="conversation_list_item_background_unread">@drawable/conversation_list_item_unread_background_dark</item>
@@ -230,7 +230,7 @@
         <item name="encrypted_backup">@drawable/ic_lock_dark</item>
         <item name="plaintext_backup">@drawable/ic_content_copy_dark</item>
 
-        <item name="fab_color">@color/smssecure_primary_dark</item>
+        <item name="fab_color">@color/silence_primary_dark</item>
         <item name="lower_right_divet">@drawable/divet_lower_right_light</item>
 
         <item name="conversation_background">#22ffffff</item>
@@ -286,7 +286,7 @@
         <item name="conversation_icon_attach_audio">@drawable/ic_audio_dark</item>
         <item name="conversation_icon_attach_video">@drawable/ic_video_dark</item>
 
-        <item name="reminder_header_background">@color/smssecure_primary_dark</item>
+        <item name="reminder_header_background">@color/silence_primary_dark</item>
 
         <item name="pref_ic_push">@drawable/ic_push_gray</item>
         <item name="pref_ic_sms_mms">@drawable/ic_textsms_grey_32dp</item>

--- a/res/xml/preferences_sms_mms.xml
+++ b/res/xml/preferences_sms_mms.xml
@@ -4,18 +4,18 @@
     <org.smssecure.smssecure.components.SwitchPreferenceCompat
                         android:defaultValue="true"
                         android:key="pref_all_sms"
-                        android:summary="@string/preferences__use_textsecure_for_viewing_and_storing_all_incoming_text_messages"
+                        android:summary="@string/preferences__use_silence_for_viewing_and_storing_all_incoming_text_messages"
                         android:title="@string/preferences__pref_all_sms_title" />
 
     <org.smssecure.smssecure.components.SwitchPreferenceCompat
                         android:defaultValue="true"
                         android:key="pref_all_mms"
-                        android:summary="@string/preferences__use_textsecure_for_viewing_and_storing_all_incoming_multimedia_messages"
+                        android:summary="@string/preferences__use_silence_for_viewing_and_storing_all_incoming_multimedia_messages"
                         android:title="@string/preferences__pref_all_mms_title" />
 
     <Preference android:key="pref_set_default"
                 android:title="@string/preferences__make_default_sms_app"
-                android:summary="@string/preferences__make_textsecure_the_default_sms_mms_app" />
+                android:summary="@string/preferences__make_silence_the_default_sms_mms_app" />
 
     <org.smssecure.smssecure.components.SwitchPreferenceCompat
                         android:key="pref_show_sent_time"

--- a/src/org/smssecure/smssecure/ApplicationContext.java
+++ b/src/org/smssecure/smssecure/ApplicationContext.java
@@ -25,7 +25,7 @@ import org.smssecure.smssecure.jobs.persistence.EncryptingJobSerializer;
 import org.smssecure.smssecure.jobs.requirements.MasterSecretRequirementProvider;
 import org.smssecure.smssecure.jobs.requirements.MediaNetworkRequirementProvider;
 import org.smssecure.smssecure.jobs.requirements.ServiceRequirementProvider;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.whispersystems.jobqueue.JobManager;
 import org.whispersystems.jobqueue.dependencies.DependencyInjector;
 import org.whispersystems.jobqueue.requirements.NetworkRequirementProvider;
@@ -37,7 +37,7 @@ import java.security.Security;
 import dagger.ObjectGraph;
 
 /**
- * Will be called once when the SMSSecure process is created.
+ * Will be called once when the Silence process is created.
  *
  * We're using this as an insertion point to patch up the Android PRNG disaster
  * and to initialize the job manager.
@@ -83,7 +83,7 @@ public class ApplicationContext extends Application implements DependencyInjecto
 
   private void initializeJobManager() {
     this.jobManager = JobManager.newBuilder(this)
-                                .withName("SMSSecureJobs")
+                                .withName("SilenceJobs")
                                 .withDependencyInjector(this)
                                 .withJobSerializer(new EncryptingJobSerializer())
                                 .withRequirementProviders(new MasterSecretRequirementProvider(this),

--- a/src/org/smssecure/smssecure/ApplicationPreferencesActivity.java
+++ b/src/org/smssecure/smssecure/ApplicationPreferencesActivity.java
@@ -46,7 +46,7 @@ import org.smssecure.smssecure.util.DynamicLanguage;
 import org.smssecure.smssecure.util.DynamicTheme;
 import org.smssecure.smssecure.util.task.ProgressDialogAsyncTask;
 import org.smssecure.smssecure.util.ResUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.whispersystems.libaxolotl.util.guava.Optional;
 
 import java.io.IOException;
@@ -122,10 +122,10 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
 
   @Override
   public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-    if (key.equals(SMSSecurePreferences.THEME_PREF)) {
+    if (key.equals(SilencePreferences.THEME_PREF)) {
       if (VERSION.SDK_INT >= 11) recreate();
       else                       dynamicTheme.onResume(this);
-    } else if (key.equals(SMSSecurePreferences.LANGUAGE_PREF)) {
+    } else if (key.equals(SilencePreferences.LANGUAGE_PREF)) {
       if (VERSION.SDK_INT >= 11) recreate();
       else                       dynamicLanguage.onResume(this);
 

--- a/src/org/smssecure/smssecure/BaseActionBarActivity.java
+++ b/src/org/smssecure/smssecure/BaseActionBarActivity.java
@@ -15,7 +15,7 @@ import android.view.ViewConfiguration;
 import android.view.WindowManager;
 import android.view.animation.AnimationUtils;
 
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 import java.lang.reflect.Field;
 
@@ -53,7 +53,7 @@ public abstract class BaseActionBarActivity extends AppCompatActivity {
 
   private void initializeScreenshotSecurity() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH &&
-            SMSSecurePreferences.isScreenSecurityEnabled(this))
+            SilencePreferences.isScreenSecurityEnabled(this))
     {
       getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
     } else {

--- a/src/org/smssecure/smssecure/ContactSelectionListFragment.java
+++ b/src/org/smssecure/smssecure/ContactSelectionListFragment.java
@@ -38,7 +38,7 @@ import org.smssecure.smssecure.contacts.ContactSelectionListAdapter;
 import org.smssecure.smssecure.contacts.ContactSelectionListItem;
 import org.smssecure.smssecure.contacts.ContactsCursorLoader;
 import org.smssecure.smssecure.database.CursorRecyclerViewAdapter;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.ViewUtil;
 
 import java.util.HashMap;

--- a/src/org/smssecure/smssecure/ConversationActivity.java
+++ b/src/org/smssecure/smssecure/ConversationActivity.java
@@ -112,7 +112,7 @@ import org.smssecure.smssecure.util.DynamicLanguage;
 import org.smssecure.smssecure.util.DynamicTheme;
 import org.smssecure.smssecure.util.GroupUtil;
 import org.smssecure.smssecure.util.MediaUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.TelephonyUtil;
 import org.smssecure.smssecure.util.Util;
 import org.smssecure.smssecure.util.ViewUtil;
@@ -468,7 +468,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void handleInviteLink() {
-    composeText.appendInvite(getString(R.string.ConversationActivity_install_smssecure, "http://smssecure.org"));
+    composeText.appendInvite(getString(R.string.ConversationActivity_install_smssecure, "http://silence.im"));
   }
 
   private void handleVerifyIdentity() {
@@ -795,7 +795,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     composeBubble  = ViewUtil.findById(this, R.id.compose_bubble);
     container      = ViewUtil.findById(this, R.id.layout_container);
 
-    if (SMSSecurePreferences.isEmojiDrawerDisabled(this))
+    if (SilencePreferences.isEmojiDrawerDisabled(this))
       emojiToggle.setVisibility(View.GONE);
 
     container.addOnKeyboardShownListener(this);
@@ -1332,7 +1332,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     public boolean onKey(View v, int keyCode, KeyEvent event) {
       if (event.getAction() == KeyEvent.ACTION_DOWN) {
         if (keyCode == KeyEvent.KEYCODE_ENTER) {
-          if (SMSSecurePreferences.getEnterKeyType(ConversationActivity.this).equals("send")) {
+          if (SilencePreferences.getEnterKeyType(ConversationActivity.this).equals("send")) {
             sendButton.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER));
             sendButton.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER));
             return true;

--- a/src/org/smssecure/smssecure/ConversationItem.java
+++ b/src/org/smssecure/smssecure/ConversationItem.java
@@ -445,7 +445,7 @@ public class ConversationItem extends LinearLayout
 
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         builder.setTitle(R.string.ConversationActivity_initiate_secure_session_question);
-        builder.setMessage(R.string.ConversationActivity_detected_smssecure_initiate_session_question);
+        builder.setMessage(R.string.ConversationActivity_detected_silence_initiate_session_question);
         builder.setIconAttribute(R.attr.dialog_info_icon);
         builder.setCancelable(true);
         builder.setNegativeButton(R.string.no, null);

--- a/src/org/smssecure/smssecure/ConversationListActivity.java
+++ b/src/org/smssecure/smssecure/ConversationListActivity.java
@@ -38,7 +38,7 @@ import org.smssecure.smssecure.recipients.Recipients;
 import org.smssecure.smssecure.service.KeyCachingService;
 import org.smssecure.smssecure.util.DynamicLanguage;
 import org.smssecure.smssecure.util.DynamicTheme;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 public class ConversationListActivity extends PassphraseRequiredActionBarActivity
     implements ConversationListFragment.ConversationSelectedListener
@@ -89,7 +89,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
 
     inflater.inflate(R.menu.text_secure_normal, menu);
 
-    menu.findItem(R.id.menu_clear_passphrase).setVisible(!SMSSecurePreferences.isPasswordDisabled(this));
+    menu.findItem(R.id.menu_clear_passphrase).setVisible(!SilencePreferences.isPasswordDisabled(this));
 
     inflater.inflate(R.menu.conversation_list, menu);
     MenuItem menuItem = menu.findItem(R.id.menu_search);

--- a/src/org/smssecure/smssecure/ConversationListItem.java
+++ b/src/org/smssecure/smssecure/ConversationListItem.java
@@ -128,7 +128,7 @@ public class ConversationListItem extends RelativeLayout
 
     if (thread.getDate() > 0) {
       CharSequence date = DateUtils.getBriefRelativeTimeSpanString(getContext(), locale, thread.getDate());
-      dateView.setText(read ? date : color(getResources().getColor(R.color.smssecure_primary), date));
+      dateView.setText(read ? date : color(getResources().getColor(R.color.silence_primary), date));
       dateView.setTypeface(read ? LIGHT_TYPEFACE : BOLD_TYPEFACE);
     }
 

--- a/src/org/smssecure/smssecure/GroupMembersDialog.java
+++ b/src/org/smssecure/smssecure/GroupMembersDialog.java
@@ -15,7 +15,7 @@ import org.smssecure.smssecure.recipients.RecipientFactory;
 import org.smssecure.smssecure.recipients.Recipients;
 import org.smssecure.smssecure.util.GroupUtil;
 import org.smssecure.smssecure.util.InvalidNumberException;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Util;
 
 import java.io.IOException;
@@ -135,7 +135,7 @@ public class GroupMembersDialog extends AsyncTask<Void, Void, Recipients> {
 
     private boolean isLocalNumber(Recipient recipient) {
       try {
-        String localNumber = SMSSecurePreferences.getLocalNumber(context);
+        String localNumber = SilencePreferences.getLocalNumber(context);
         String e164Number  = Util.canonicalizeNumber(context, recipient.getNumber());
 
         return e164Number != null && e164Number.equals(localNumber);

--- a/src/org/smssecure/smssecure/MediaOverviewActivity.java
+++ b/src/org/smssecure/smssecure/MediaOverviewActivity.java
@@ -73,7 +73,7 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity i
 
   @Override
   protected void onPreCreate() {
-    this.setTheme(R.style.SMSSecure_DarkTheme);
+    this.setTheme(R.style.Silence_DarkTheme);
     dynamicLanguage.onCreate(this);
   }
 

--- a/src/org/smssecure/smssecure/MediaPreviewActivity.java
+++ b/src/org/smssecure/smssecure/MediaPreviewActivity.java
@@ -64,7 +64,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
   @Override
   protected void onCreate(Bundle bundle, @NonNull MasterSecret masterSecret) {
     this.masterSecret = masterSecret;
-    this.setTheme(R.style.SMSSecure_DarkTheme);
+    this.setTheme(R.style.Silence_DarkTheme);
     dynamicLanguage.onCreate(this);
 
     setFullscreenIfPossible();

--- a/src/org/smssecure/smssecure/MessageDetailsActivity.java
+++ b/src/org/smssecure/smssecure/MessageDetailsActivity.java
@@ -50,7 +50,7 @@ import org.smssecure.smssecure.util.DateUtils;
 import org.smssecure.smssecure.util.DynamicLanguage;
 import org.smssecure.smssecure.util.DynamicTheme;
 import org.smssecure.smssecure.util.GroupUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Util;
 
 import java.io.IOException;
@@ -183,7 +183,7 @@ public class MessageDetailsActivity extends PassphraseRequiredActionBarActivity 
   }
 
   private void updateTime(Context context, MessageRecord messageRecord) {
-    boolean isSmsDeliveryReportsEnabled = SMSSecurePreferences.isSmsDeliveryReportsEnabled(context);
+    boolean isSmsDeliveryReportsEnabled = SilencePreferences.isSmsDeliveryReportsEnabled(context);
 
     if (messageRecord.isPending() || messageRecord.isFailed()) {
       sentDate.setText("-");

--- a/src/org/smssecure/smssecure/PanicResponderActivity.java
+++ b/src/org/smssecure/smssecure/PanicResponderActivity.java
@@ -7,7 +7,7 @@ import android.os.Bundle;
 
 import org.iilab.IilabEngineeringRSA2048Pin;
 import org.smssecure.smssecure.service.KeyCachingService;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 import info.guardianproject.GuardianProjectRSA4096;
 import info.guardianproject.trustedintents.TrustedIntents;
@@ -30,7 +30,7 @@ public class PanicResponderActivity extends Activity {
 
     Intent intent = trustedIntents.getIntentFromTrustedSender(this);
     if (intent != null
-            && !SMSSecurePreferences.isPasswordDisabled(this)
+            && !SilencePreferences.isPasswordDisabled(this)
             && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
       handleClearPassphrase();
       ExitActivity.exitAndRemoveFromRecentApps(this);

--- a/src/org/smssecure/smssecure/PassphraseChangeActivity.java
+++ b/src/org/smssecure/smssecure/PassphraseChangeActivity.java
@@ -31,7 +31,7 @@ import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.crypto.MasterSecretUtil;
 import org.smssecure.smssecure.util.DynamicLanguage;
 import org.smssecure.smssecure.util.DynamicTheme;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 /**
  * Activity for changing a user's local encryption passphrase.
@@ -79,7 +79,7 @@ public class PassphraseChangeActivity extends PassphraseActivity {
     this.okButton.setOnClickListener(new OkButtonClickListener());
     this.cancelButton.setOnClickListener(new CancelButtonClickListener());
 
-    if (SMSSecurePreferences.isPasswordDisabled(this)) {
+    if (SilencePreferences.isPasswordDisabled(this)) {
       this.originalPassphrase.setVisibility(View.GONE);
     } else {
       this.originalPassphrase.setVisibility(View.VISIBLE);
@@ -112,7 +112,7 @@ public class PassphraseChangeActivity extends PassphraseActivity {
       passphraseRepeat = (repeatText == null ? "" : repeatText.toString());
     }
 
-    if (SMSSecurePreferences.isPasswordDisabled(this)) {
+    if (SilencePreferences.isPasswordDisabled(this)) {
       original = MasterSecretUtil.UNENCRYPTED_PASSPHRASE;
     }
 
@@ -157,7 +157,7 @@ public class PassphraseChangeActivity extends PassphraseActivity {
     protected MasterSecret doInBackground(String... params) {
       try {
         MasterSecret masterSecret = MasterSecretUtil.changeMasterSecretPassphrase(context, params[0], params[1]);
-        SMSSecurePreferences.setPasswordDisabled(context, false);
+        SilencePreferences.setPasswordDisabled(context, false);
 
         return masterSecret;
 

--- a/src/org/smssecure/smssecure/PassphraseCreateActivity.java
+++ b/src/org/smssecure/smssecure/PassphraseCreateActivity.java
@@ -23,7 +23,7 @@ import android.support.v7.app.ActionBar;
 import org.smssecure.smssecure.crypto.IdentityKeyUtil;
 import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.crypto.MasterSecretUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.VersionTracker;
 
 /**
@@ -68,7 +68,7 @@ public class PassphraseCreateActivity extends PassphraseActivity {
       MasterSecretUtil.generateAsymmetricMasterSecret(PassphraseCreateActivity.this, masterSecret);
       IdentityKeyUtil.generateIdentityKeys(PassphraseCreateActivity.this, masterSecret);
       VersionTracker.updateLastSeenVersion(PassphraseCreateActivity.this);
-      SMSSecurePreferences.setPasswordDisabled(PassphraseCreateActivity.this, true);
+      SilencePreferences.setPasswordDisabled(PassphraseCreateActivity.this, true);
 
       return null;
     }

--- a/src/org/smssecure/smssecure/PassphraseRequiredActionBarActivity.java
+++ b/src/org/smssecure/smssecure/PassphraseRequiredActionBarActivity.java
@@ -16,7 +16,7 @@ import android.view.WindowManager;
 import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.crypto.MasterSecretUtil;
 import org.smssecure.smssecure.service.KeyCachingService;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 import java.util.Locale;
 
@@ -139,7 +139,7 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
   private int getApplicationState(MasterSecret masterSecret) {
     if (!MasterSecretUtil.isPassphraseInitialized(this)) {
       return STATE_CREATE_PASSPHRASE;
-    } else if (SMSSecurePreferences.isFirstRun(this)) {
+    } else if (SilencePreferences.isFirstRun(this)) {
       return STATE_INTRO_SCREEN;
     } else if (masterSecret == null) {
       return STATE_PROMPT_PASSPHRASE;

--- a/src/org/smssecure/smssecure/PushContactSelectionActivity.java
+++ b/src/org/smssecure/smssecure/PushContactSelectionActivity.java
@@ -28,7 +28,7 @@ import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.util.DynamicLanguage;
 import org.smssecure.smssecure.util.DynamicNoActionBarTheme;
 import org.smssecure.smssecure.util.DynamicTheme;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/org/smssecure/smssecure/ReceiveKeyDialog.java
+++ b/src/org/smssecure/smssecure/ReceiveKeyDialog.java
@@ -31,7 +31,7 @@ import android.widget.TextView;
 
 import org.smssecure.smssecure.crypto.IdentityKeyParcelable;
 import org.smssecure.smssecure.crypto.MasterSecret;
-import org.smssecure.smssecure.crypto.storage.SMSSecureIdentityKeyStore;
+import org.smssecure.smssecure.crypto.storage.SilenceIdentityKeyStore;
 import org.smssecure.smssecure.database.DatabaseFactory;
 import org.smssecure.smssecure.database.EncryptingSmsDatabase;
 import org.smssecure.smssecure.database.IdentityDatabase;
@@ -121,7 +121,7 @@ public class ReceiveKeyDialog extends AlertDialog {
   }
 
   private boolean isTrusted(MasterSecret masterSecret, IdentityKey identityKey, Recipient recipient) {
-    IdentityKeyStore identityKeyStore = new SMSSecureIdentityKeyStore(getContext(), masterSecret);
+    IdentityKeyStore identityKeyStore = new SilenceIdentityKeyStore(getContext(), masterSecret);
 
     return identityKeyStore.isTrustedIdentity(recipient.getNumber(), identityKey);
   }

--- a/src/org/smssecure/smssecure/SMSSecureExpiredException.java
+++ b/src/org/smssecure/smssecure/SMSSecureExpiredException.java
@@ -1,7 +1,0 @@
-package org.smssecure.smssecure;
-
-public class SMSSecureExpiredException extends Exception {
-  public SMSSecureExpiredException(String message) {
-    super(message);
-  }
-}

--- a/src/org/smssecure/smssecure/TransportOptions.java
+++ b/src/org/smssecure/smssecure/TransportOptions.java
@@ -129,7 +129,7 @@ public class TransportOptions {
                                                     context.getString(R.string.conversation_activity__type_message_mms_insecure),
                                                     new MmsCharacterCalculator()));
       results.addAll(getTransportOptionsForSimCards(Type.SECURE_SMS, R.drawable.ic_send_secure_white_24dp,
-                                                    context.getResources().getColor(R.color.smssecure_primary),
+                                                    context.getResources().getColor(R.color.silence_primary),
                                                     context.getString(R.string.ConversationActivity_transport_secure_mms),
                                                     context.getString(R.string.conversation_activity__type_message_mms_secure),
                                                     new MmsCharacterCalculator()));
@@ -140,7 +140,7 @@ public class TransportOptions {
                                                     context.getString(R.string.conversation_activity__type_message_sms_insecure),
                                                     new SmsCharacterCalculator()));
       results.addAll(getTransportOptionsForSimCards(Type.SECURE_SMS, R.drawable.ic_send_secure_white_24dp,
-                                                    context.getResources().getColor(R.color.smssecure_primary),
+                                                    context.getResources().getColor(R.color.silence_primary),
                                                     context.getString(R.string.ConversationActivity_transport_secure_sms),
                                                     context.getString(R.string.conversation_activity__type_message_sms_secure),
                                                     new EncryptedSmsCharacterCalculator()));

--- a/src/org/smssecure/smssecure/VerifyIdentityActivity.java
+++ b/src/org/smssecure/smssecure/VerifyIdentityActivity.java
@@ -26,7 +26,7 @@ import android.widget.Toast;
 import org.smssecure.smssecure.crypto.IdentityKeyParcelable;
 import org.smssecure.smssecure.crypto.IdentityKeyUtil;
 import org.smssecure.smssecure.crypto.MasterSecret;
-import org.smssecure.smssecure.crypto.storage.SMSSecureSessionStore;
+import org.smssecure.smssecure.crypto.storage.SilenceSessionStore;
 import org.smssecure.smssecure.recipients.Recipient;
 import org.smssecure.smssecure.recipients.RecipientFactory;
 import org.smssecure.smssecure.util.Hex;
@@ -157,7 +157,7 @@ public class VerifyIdentityActivity extends KeyScanningActivity {
       return identityKeyParcelable.get();
     }
 
-    SessionStore   sessionStore   = new SMSSecureSessionStore(this, masterSecret);
+    SessionStore   sessionStore   = new SilenceSessionStore(this, masterSecret);
     AxolotlAddress axolotlAddress = new AxolotlAddress(recipient.getNumber(), 1);
     SessionRecord  record         = sessionStore.loadSession(axolotlAddress);
 

--- a/src/org/smssecure/smssecure/color/MaterialColor.java
+++ b/src/org/smssecure/smssecure/color/MaterialColor.java
@@ -27,7 +27,7 @@ public enum MaterialColor {
   GREY       (R.color.grey_500,        R.color.grey_700,        R.color.grey_700,        R.color.grey_900,        "grey"),
   BLUE_GREY  (R.color.blue_grey_500,   R.color.blue_grey_700,   R.color.blue_grey_700,   R.color.blue_grey_900,   "blue_grey"),
 
-  GROUP      (GREY.conversationColorLight, R.color.smssecure_primary, R.color.smssecure_primary_dark,
+  GROUP      (GREY.conversationColorLight, R.color.silence_primary, R.color.silence_primary_dark,
               GREY.conversationColorDark, R.color.gray95, R.color.black,
               "group_color");
 

--- a/src/org/smssecure/smssecure/components/ComposeText.java
+++ b/src/org/smssecure/smssecure/components/ComposeText.java
@@ -17,7 +17,7 @@ import android.view.inputmethod.EditorInfo;
 import org.smssecure.smssecure.R;
 import org.smssecure.smssecure.TransportOption;
 import org.smssecure.smssecure.components.emoji.EmojiEditText;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 public class ComposeText extends EmojiEditText {
 
@@ -92,7 +92,7 @@ public class ComposeText extends EmojiEditText {
   }
 
   public void setTransport(TransportOption transport) {
-    final String enterKeyType = SMSSecurePreferences.getEnterKeyType(getContext());
+    final String enterKeyType = SilencePreferences.getEnterKeyType(getContext());
 
     int imeOptions = (getImeOptions() & ~EditorInfo.IME_MASK_ACTION) | EditorInfo.IME_ACTION_SEND;
     int inputType  = getInputType();

--- a/src/org/smssecure/smssecure/components/CustomDefaultPreference.java
+++ b/src/org/smssecure/smssecure/components/CustomDefaultPreference.java
@@ -19,7 +19,7 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import org.smssecure.smssecure.R;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -120,19 +120,19 @@ public class CustomDefaultPreference extends DialogPreference {
   }
 
   private boolean isCustom() {
-    return SMSSecurePreferences.getBooleanPreference(getContext(), customToggle, false);
+    return SilencePreferences.getBooleanPreference(getContext(), customToggle, false);
   }
 
   private void setCustom(boolean custom) {
-    SMSSecurePreferences.setBooleanPreference(getContext(), customToggle, custom);
+    SilencePreferences.setBooleanPreference(getContext(), customToggle, custom);
   }
 
   private String getCustomValue() {
-    return SMSSecurePreferences.getStringPreference(getContext(), customPreference, "");
+    return SilencePreferences.getStringPreference(getContext(), customPreference, "");
   }
 
   private void setCustomValue(String value) {
-    SMSSecurePreferences.setStringPreference(getContext(), customPreference, value);
+    SilencePreferences.setStringPreference(getContext(), customPreference, value);
   }
 
   private String getDefaultValue() {

--- a/src/org/smssecure/smssecure/components/OutgoingSmsPreference.java
+++ b/src/org/smssecure/smssecure/components/OutgoingSmsPreference.java
@@ -7,7 +7,7 @@ import android.view.View;
 import android.widget.CheckBox;
 
 import org.smssecure.smssecure.R;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 public class OutgoingSmsPreference extends DialogPreference {
   private CheckBox dataUsers;
@@ -30,10 +30,10 @@ public class OutgoingSmsPreference extends DialogPreference {
     neverFallbackMms = (CheckBox) view.findViewById(R.id.never_send_mms);
     nonDataUsers     = (CheckBox) view.findViewById(R.id.non_data_users);
 
-    dataUsers.setChecked(SMSSecurePreferences.isFallbackSmsAllowed(getContext()));
-    askForFallback.setChecked(SMSSecurePreferences.isFallbackSmsAskRequired(getContext()));
-    neverFallbackMms.setChecked(!SMSSecurePreferences.isFallbackMmsEnabled(getContext()));
-    nonDataUsers.setChecked(SMSSecurePreferences.isDirectSmsAllowed(getContext()));
+    dataUsers.setChecked(SilencePreferences.isFallbackSmsAllowed(getContext()));
+    askForFallback.setChecked(SilencePreferences.isFallbackSmsAskRequired(getContext()));
+    neverFallbackMms.setChecked(!SilencePreferences.isFallbackMmsEnabled(getContext()));
+    nonDataUsers.setChecked(SilencePreferences.isDirectSmsAllowed(getContext()));
 
     dataUsers.setOnClickListener(new View.OnClickListener() {
       @Override
@@ -55,10 +55,10 @@ public class OutgoingSmsPreference extends DialogPreference {
     super.onDialogClosed(positiveResult);
 
     if (positiveResult) {
-      SMSSecurePreferences.setFallbackSmsAllowed(getContext(), dataUsers.isChecked());
-      SMSSecurePreferences.setFallbackSmsAskRequired(getContext(), askForFallback.isChecked());
-      SMSSecurePreferences.setDirectSmsAllowed(getContext(), nonDataUsers.isChecked());
-      SMSSecurePreferences.setFallbackMmsEnabled(getContext(), !neverFallbackMms.isChecked());
+      SilencePreferences.setFallbackSmsAllowed(getContext(), dataUsers.isChecked());
+      SilencePreferences.setFallbackSmsAskRequired(getContext(), askForFallback.isChecked());
+      SilencePreferences.setDirectSmsAllowed(getContext(), nonDataUsers.isChecked());
+      SilencePreferences.setFallbackMmsEnabled(getContext(), !neverFallbackMms.isChecked());
       if (getOnPreferenceChangeListener() != null) getOnPreferenceChangeListener().onPreferenceChange(this, null);
     }
   }

--- a/src/org/smssecure/smssecure/components/reminder/DefaultSmsReminder.java
+++ b/src/org/smssecure/smssecure/components/reminder/DefaultSmsReminder.java
@@ -9,7 +9,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 
 import org.smssecure.smssecure.R;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Util;
 
 public class DefaultSmsReminder extends Reminder {
@@ -23,7 +23,7 @@ public class DefaultSmsReminder extends Reminder {
     final OnClickListener okListener = new OnClickListener() {
       @Override
       public void onClick(View v) {
-        SMSSecurePreferences.setPromptedDefaultSmsProvider(context, true);
+        SilencePreferences.setPromptedDefaultSmsProvider(context, true);
         Intent intent = new Intent(Telephony.Sms.Intents.ACTION_CHANGE_DEFAULT);
         intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, context.getPackageName());
         context.startActivity(intent);
@@ -32,7 +32,7 @@ public class DefaultSmsReminder extends Reminder {
     final OnClickListener dismissListener = new OnClickListener() {
       @Override
       public void onClick(View v) {
-        SMSSecurePreferences.setPromptedDefaultSmsProvider(context, true);
+        SilencePreferences.setPromptedDefaultSmsProvider(context, true);
       }
     };
     setOkListener(okListener);
@@ -42,9 +42,9 @@ public class DefaultSmsReminder extends Reminder {
   public static boolean isEligible(Context context) {
     final boolean isDefault = Util.isDefaultSmsProvider(context);
     if (isDefault) {
-      SMSSecurePreferences.setPromptedDefaultSmsProvider(context, false);
+      SilencePreferences.setPromptedDefaultSmsProvider(context, false);
     }
 
-    return !isDefault && !SMSSecurePreferences.hasPromptedDefaultSmsProvider(context);
+    return !isDefault && !SilencePreferences.hasPromptedDefaultSmsProvider(context);
   }
 }

--- a/src/org/smssecure/smssecure/components/reminder/StoreRatingReminder.java
+++ b/src/org/smssecure/smssecure/components/reminder/StoreRatingReminder.java
@@ -9,7 +9,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 
 import org.smssecure.smssecure.R;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 import java.util.concurrent.TimeUnit;
 
@@ -27,7 +27,7 @@ public class StoreRatingReminder extends Reminder {
     final OnClickListener okListener = new OnClickListener() {
       @Override
       public void onClick(View v) {
-        SMSSecurePreferences.setRatingEnabled(context, false);
+        SilencePreferences.setRatingEnabled(context, false);
         Uri uri = Uri.parse("market://details?id=" + context.getPackageName());
         context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
       }
@@ -35,7 +35,7 @@ public class StoreRatingReminder extends Reminder {
     final OnClickListener dismissListener = new OnClickListener() {
       @Override
       public void onClick(View v) {
-        SMSSecurePreferences.setRatingEnabled(context, false);
+        SilencePreferences.setRatingEnabled(context, false);
       }
     };
     setOkListener(okListener);
@@ -44,18 +44,18 @@ public class StoreRatingReminder extends Reminder {
 
   public static boolean isEligible(Context context) {
 
-    if (!SMSSecurePreferences.isRatingEnabled(context))
+    if (!SilencePreferences.isRatingEnabled(context))
       return false;
 
     // App needs to be installed via Play/Amazon store to show the rating dialog
     String installer = context.getPackageManager().getInstallerPackageName(context.getPackageName());
     if (installer == null || !(installer.equals("com.android.vending") || installer.equals("com.amazon.venezia"))){
-      SMSSecurePreferences.setRatingEnabled(context, false);
+      SilencePreferences.setRatingEnabled(context, false);
       return false;
     }
 
     long daysSinceInstall = getDaysSinceInstalled(context);
-    long laterTimestamp   = SMSSecurePreferences.getRatingLaterTimestamp(context);
+    long laterTimestamp   = SilencePreferences.getRatingLaterTimestamp(context);
 
     return daysSinceInstall >= DAYS_SINCE_INSTALL_THRESHOLD &&
             System.currentTimeMillis() >= laterTimestamp;

--- a/src/org/smssecure/smssecure/contacts/ContactsCursorLoader.java
+++ b/src/org/smssecure/smssecure/contacts/ContactsCursorLoader.java
@@ -52,7 +52,7 @@ public class ContactsCursorLoader extends CursorLoader {
     ContactsDatabase  contactsDatabase = DatabaseFactory.getContactsDatabase(getContext());
     ArrayList<Cursor> cursorList       = new ArrayList<>(3);
 
-    cursorList.add(contactsDatabase.querySMSSecureContacts(filter));
+    cursorList.add(contactsDatabase.querySilenceContacts(filter));
 
     if (includeSmsContacts) {
       cursorList.add(contactsDatabase.querySystemContacts(filter));

--- a/src/org/smssecure/smssecure/contacts/ContactsDatabase.java
+++ b/src/org/smssecure/smssecure/contacts/ContactsDatabase.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Database to supply all types of contacts that SMSSecure needs to know about
+ * Database to supply all types of contacts that Silence needs to know about
  *
  * @author Jake McGinty
  */
@@ -100,7 +100,7 @@ public class ContactsDatabase {
                                        new Pair<String, Object>(CONTACT_TYPE_COLUMN, NORMAL_TYPE));
   }
 
-  public @NonNull Cursor querySMSSecureContacts(String filter) {
+  public @NonNull Cursor querySilenceContacts(String filter) {
     String[] projection = new String[] {ContactsContract.Data._ID,
                                         ContactsContract.Contacts.DISPLAY_NAME,
                                         ContactsContract.Data.DATA1};
@@ -131,7 +131,7 @@ public class ContactsDatabase {
     }
 
     return new ProjectionMappingCursor(cursor, projectionMap,
-                                       new Pair<String, Object>(LABEL_COLUMN, "SMSSecure"),
+                                       new Pair<String, Object>(LABEL_COLUMN, "Silence"),
                                        new Pair<String, Object>(NUMBER_TYPE_COLUMN, 0),
                                        new Pair<String, Object>(CONTACT_TYPE_COLUMN, PUSH_TYPE));
 

--- a/src/org/smssecure/smssecure/crypto/AsymmetricMasterCipher.java
+++ b/src/org/smssecure/smssecure/crypto/AsymmetricMasterCipher.java
@@ -35,7 +35,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 /**
  * This class is used to asymmetricly encrypt local data.  This is used in the case
- * where SMSSecure receives an SMS, but the user's local encryption passphrase is
+ * where Silence receives an SMS, but the user's local encryption passphrase is
  * not cached (either because of a timeout, or because it hasn't yet been entered).
  *
  * In this case, we have access to the public key of a local keypair.  We encrypt

--- a/src/org/smssecure/smssecure/crypto/AsymmetricMasterSecret.java
+++ b/src/org/smssecure/smssecure/crypto/AsymmetricMasterSecret.java
@@ -21,7 +21,7 @@ import org.whispersystems.libaxolotl.ecc.ECPrivateKey;
 import org.whispersystems.libaxolotl.ecc.ECPublicKey;
 
 /**
- * When a user first initializes SMSSecure, a few secrets
+ * When a user first initializes Silence, a few secrets
  * are generated.  These are:
  *
  * 1) A 128bit symmetric encryption key.

--- a/src/org/smssecure/smssecure/crypto/KeyExchangeInitiator.java
+++ b/src/org/smssecure/smssecure/crypto/KeyExchangeInitiator.java
@@ -22,9 +22,9 @@ import android.content.Context;
 import android.content.DialogInterface;
 
 import org.smssecure.smssecure.R;
-import org.smssecure.smssecure.crypto.storage.SMSSecureIdentityKeyStore;
-import org.smssecure.smssecure.crypto.storage.SMSSecurePreKeyStore;
-import org.smssecure.smssecure.crypto.storage.SMSSecureSessionStore;
+import org.smssecure.smssecure.crypto.storage.SilenceIdentityKeyStore;
+import org.smssecure.smssecure.crypto.storage.SilencePreKeyStore;
+import org.smssecure.smssecure.crypto.storage.SilenceSessionStore;
 import org.smssecure.smssecure.recipients.Recipient;
 import org.smssecure.smssecure.recipients.RecipientFactory;
 import org.smssecure.smssecure.recipients.Recipients;
@@ -64,10 +64,10 @@ public class KeyExchangeInitiator {
 
   private static void initiateKeyExchange(Context context, MasterSecret masterSecret, Recipients recipients, int subscriptionId) {
     Recipient         recipient         = recipients.getPrimaryRecipient();
-    SessionStore      sessionStore      = new SMSSecureSessionStore(context, masterSecret);
-    PreKeyStore       preKeyStore       = new SMSSecurePreKeyStore(context, masterSecret);
-    SignedPreKeyStore signedPreKeyStore = new SMSSecurePreKeyStore(context, masterSecret);
-    IdentityKeyStore  identityKeyStore  = new SMSSecureIdentityKeyStore(context, masterSecret);
+    SessionStore      sessionStore      = new SilenceSessionStore(context, masterSecret);
+    PreKeyStore       preKeyStore       = new SilencePreKeyStore(context, masterSecret);
+    SignedPreKeyStore signedPreKeyStore = new SilencePreKeyStore(context, masterSecret);
+    IdentityKeyStore  identityKeyStore  = new SilenceIdentityKeyStore(context, masterSecret);
 
     SessionBuilder    sessionBuilder    = new SessionBuilder(sessionStore, preKeyStore, signedPreKeyStore,
                                                              identityKeyStore, new AxolotlAddress(recipient.getNumber(), 1));
@@ -83,7 +83,7 @@ public class KeyExchangeInitiator {
                                              Recipients recipients)
   {
     Recipient     recipient     = recipients.getPrimaryRecipient();
-    SessionStore  sessionStore  = new SMSSecureSessionStore(context, masterSecret);
+    SessionStore  sessionStore  = new SilenceSessionStore(context, masterSecret);
     SessionRecord sessionRecord = sessionStore.loadSession(new AxolotlAddress(recipient.getNumber(), 1));
 
     return sessionRecord.getSessionState().hasPendingKeyExchange();

--- a/src/org/smssecure/smssecure/crypto/MasterSecret.java
+++ b/src/org/smssecure/smssecure/crypto/MasterSecret.java
@@ -23,7 +23,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.util.Arrays;
 
 /**
- * When a user first initializes SMSSecure, a few secrets
+ * When a user first initializes Silence, a few secrets
  * are generated.  These are:
  *
  * 1) A 128bit symmetric encryption key.

--- a/src/org/smssecure/smssecure/crypto/PreKeyUtil.java
+++ b/src/org/smssecure/smssecure/crypto/PreKeyUtil.java
@@ -22,7 +22,7 @@ import android.util.Log;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.smssecure.smssecure.crypto.storage.SMSSecurePreKeyStore;
+import org.smssecure.smssecure.crypto.storage.SilencePreKeyStore;
 import org.smssecure.smssecure.util.JsonUtils;
 import org.smssecure.smssecure.util.Util;
 import org.whispersystems.libaxolotl.IdentityKeyPair;
@@ -49,7 +49,7 @@ public class PreKeyUtil {
   public static final int BATCH_SIZE = 100;
 
   public static List<PreKeyRecord> generatePreKeys(Context context, MasterSecret masterSecret) {
-    PreKeyStore        preKeyStore    = new SMSSecurePreKeyStore(context, masterSecret);
+    PreKeyStore        preKeyStore    = new SilencePreKeyStore(context, masterSecret);
     List<PreKeyRecord> records        = new LinkedList<>();
     int                preKeyIdOffset = getNextPreKeyId(context);
 
@@ -70,7 +70,7 @@ public class PreKeyUtil {
                                                         IdentityKeyPair identityKeyPair)
   {
     try {
-      SignedPreKeyStore  signedPreKeyStore = new SMSSecurePreKeyStore(context, masterSecret);
+      SignedPreKeyStore  signedPreKeyStore = new SilencePreKeyStore(context, masterSecret);
       int                signedPreKeyId    = getNextSignedPreKeyId(context);
       ECKeyPair          keyPair           = Curve.generateKeyPair();
       byte[]             signature         = Curve.calculateSignature(identityKeyPair.getPrivateKey(), keyPair.getPublicKey().serialize());
@@ -86,7 +86,7 @@ public class PreKeyUtil {
   }
 
   public static PreKeyRecord generateLastResortKey(Context context, MasterSecret masterSecret) {
-    PreKeyStore preKeyStore = new SMSSecurePreKeyStore(context, masterSecret);
+    PreKeyStore preKeyStore = new SilencePreKeyStore(context, masterSecret);
 
     if (preKeyStore.containsPreKey(Medium.MAX_VALUE)) {
       try {
@@ -164,11 +164,11 @@ public class PreKeyUtil {
   }
 
   private static File getPreKeysDirectory(Context context) {
-    return getKeysDirectory(context, SMSSecurePreKeyStore.PREKEY_DIRECTORY);
+    return getKeysDirectory(context, SilencePreKeyStore.PREKEY_DIRECTORY);
   }
 
   private static File getSignedPreKeysDirectory(Context context) {
-    return getKeysDirectory(context, SMSSecurePreKeyStore.SIGNED_PREKEY_DIRECTORY);
+    return getKeysDirectory(context, SilencePreKeyStore.SIGNED_PREKEY_DIRECTORY);
   }
 
   private static File getKeysDirectory(Context context, String name) {

--- a/src/org/smssecure/smssecure/crypto/SessionUtil.java
+++ b/src/org/smssecure/smssecure/crypto/SessionUtil.java
@@ -3,7 +3,7 @@ package org.smssecure.smssecure.crypto;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
-import org.smssecure.smssecure.crypto.storage.SMSSecureSessionStore;
+import org.smssecure.smssecure.crypto.storage.SilenceSessionStore;
 import org.smssecure.smssecure.recipients.Recipient;
 import org.whispersystems.libaxolotl.AxolotlAddress;
 import org.whispersystems.libaxolotl.state.SessionStore;
@@ -15,7 +15,7 @@ public class SessionUtil {
   }
 
   public static boolean hasSession(Context context, MasterSecret masterSecret, @NonNull String number) {
-    SessionStore   sessionStore   = new SMSSecureSessionStore(context, masterSecret);
+    SessionStore   sessionStore   = new SilenceSessionStore(context, masterSecret);
     AxolotlAddress axolotlAddress = new AxolotlAddress(number, 1);
 
     return sessionStore.containsSession(axolotlAddress);

--- a/src/org/smssecure/smssecure/crypto/storage/SilenceAxolotlStore.java
+++ b/src/org/smssecure/smssecure/crypto/storage/SilenceAxolotlStore.java
@@ -18,18 +18,18 @@ import org.whispersystems.libaxolotl.state.SignedPreKeyStore;
 
 import java.util.List;
 
-public class SMSSecureAxolotlStore implements AxolotlStore {
+public class SilenceAxolotlStore implements AxolotlStore {
 
   private final PreKeyStore       preKeyStore;
   private final SignedPreKeyStore signedPreKeyStore;
   private final IdentityKeyStore  identityKeyStore;
   private final SessionStore      sessionStore;
 
-  public SMSSecureAxolotlStore(Context context, MasterSecret masterSecret) {
-    this.preKeyStore       = new SMSSecurePreKeyStore(context, masterSecret);
-    this.signedPreKeyStore = new SMSSecurePreKeyStore(context, masterSecret);
-    this.identityKeyStore  = new SMSSecureIdentityKeyStore(context, masterSecret);
-    this.sessionStore      = new SMSSecureSessionStore(context, masterSecret);
+  public SilenceAxolotlStore(Context context, MasterSecret masterSecret) {
+    this.preKeyStore       = new SilencePreKeyStore(context, masterSecret);
+    this.signedPreKeyStore = new SilencePreKeyStore(context, masterSecret);
+    this.identityKeyStore  = new SilenceIdentityKeyStore(context, masterSecret);
+    this.sessionStore      = new SilenceSessionStore(context, masterSecret);
   }
 
   @Override

--- a/src/org/smssecure/smssecure/crypto/storage/SilenceIdentityKeyStore.java
+++ b/src/org/smssecure/smssecure/crypto/storage/SilenceIdentityKeyStore.java
@@ -6,17 +6,17 @@ import org.smssecure.smssecure.crypto.IdentityKeyUtil;
 import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.database.DatabaseFactory;
 import org.smssecure.smssecure.recipients.RecipientFactory;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.whispersystems.libaxolotl.IdentityKey;
 import org.whispersystems.libaxolotl.IdentityKeyPair;
 import org.whispersystems.libaxolotl.state.IdentityKeyStore;
 
-public class SMSSecureIdentityKeyStore implements IdentityKeyStore {
+public class SilenceIdentityKeyStore implements IdentityKeyStore {
 
   private final Context      context;
   private final MasterSecret masterSecret;
 
-  public SMSSecureIdentityKeyStore(Context context, MasterSecret masterSecret) {
+  public SilenceIdentityKeyStore(Context context, MasterSecret masterSecret) {
     this.context      = context;
     this.masterSecret = masterSecret;
   }
@@ -28,7 +28,7 @@ public class SMSSecureIdentityKeyStore implements IdentityKeyStore {
 
   @Override
   public int getLocalRegistrationId() {
-    return SMSSecurePreferences.getLocalRegistrationId(context);
+    return SilencePreferences.getLocalRegistrationId(context);
   }
 
   @Override

--- a/src/org/smssecure/smssecure/crypto/storage/SilencePreKeyStore.java
+++ b/src/org/smssecure/smssecure/crypto/storage/SilencePreKeyStore.java
@@ -22,7 +22,7 @@ import java.nio.channels.FileChannel;
 import java.util.LinkedList;
 import java.util.List;
 
-public class SMSSecurePreKeyStore implements PreKeyStore, SignedPreKeyStore {
+public class SilencePreKeyStore implements PreKeyStore, SignedPreKeyStore {
 
   public  static final String PREKEY_DIRECTORY        = "prekeys";
   public  static final String SIGNED_PREKEY_DIRECTORY = "signed_prekeys";
@@ -30,12 +30,12 @@ public class SMSSecurePreKeyStore implements PreKeyStore, SignedPreKeyStore {
 
   private static final int    CURRENT_VERSION_MARKER = 1;
   private static final Object FILE_LOCK              = new Object();
-  private static final String TAG                    = SMSSecurePreKeyStore.class.getSimpleName();
+  private static final String TAG                    = SilencePreKeyStore.class.getSimpleName();
 
   private final Context      context;
   private final MasterSecret masterSecret;
 
-  public SMSSecurePreKeyStore(Context context, MasterSecret masterSecret) {
+  public SilencePreKeyStore(Context context, MasterSecret masterSecret) {
     this.context      = context;
     this.masterSecret = masterSecret;
   }

--- a/src/org/smssecure/smssecure/crypto/storage/SilenceSessionStore.java
+++ b/src/org/smssecure/smssecure/crypto/storage/SilenceSessionStore.java
@@ -25,9 +25,9 @@ import java.util.List;
 
 import static org.whispersystems.libaxolotl.state.StorageProtos.SessionStructure;
 
-public class SMSSecureSessionStore implements SessionStore {
+public class SilenceSessionStore implements SessionStore {
 
-  private static final String TAG                   = SMSSecureSessionStore.class.getSimpleName();
+  private static final String TAG                   = SilenceSessionStore.class.getSimpleName();
   private static final String SESSIONS_DIRECTORY_V2 = "sessions-v2";
   private static final Object FILE_LOCK             = new Object();
 
@@ -38,7 +38,7 @@ public class SMSSecureSessionStore implements SessionStore {
   private final Context      context;
   private final MasterSecret masterSecret;
 
-  public SMSSecureSessionStore(Context context, MasterSecret masterSecret) {
+  public SilenceSessionStore(Context context, MasterSecret masterSecret) {
     this.context      = context.getApplicationContext();
     this.masterSecret = masterSecret;
   }

--- a/src/org/smssecure/smssecure/database/ApnDatabase.java
+++ b/src/org/smssecure/smssecure/database/ApnDatabase.java
@@ -25,7 +25,7 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import org.smssecure.smssecure.mms.LegacyMmsConnection.Apn;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Util;
 import org.whispersystems.libaxolotl.util.guava.Optional;
 
@@ -100,15 +100,15 @@ public class ApnDatabase {
   }
 
   private Apn getCustomApnParameters() {
-      String mmsc = SMSSecurePreferences.getMmscUrl(context).trim();
+      String mmsc = SilencePreferences.getMmscUrl(context).trim();
 
       if (!TextUtils.isEmpty(mmsc) && !mmsc.startsWith("http"))
         mmsc = "http://" + mmsc;
 
-      String proxy = SMSSecurePreferences.getMmscProxy(context);
-      String port  = SMSSecurePreferences.getMmscProxyPort(context);
-      String user  = SMSSecurePreferences.getMmscUsername(context);
-      String pass  = SMSSecurePreferences.getMmscPassword(context);
+      String proxy = SilencePreferences.getMmscProxy(context);
+      String port  = SilencePreferences.getMmscProxyPort(context);
+      String user  = SilencePreferences.getMmscUsername(context);
+      String pass  = SilencePreferences.getMmscPassword(context);
 
       return new Apn(mmsc, proxy, port, user, pass);
   }
@@ -162,11 +162,11 @@ public class ApnDatabase {
     Apn customApn  = getCustomApnParameters();
     Apn defaultApn = getDefaultApnParameters(mccmnc, apn);
     Apn result     = new Apn(customApn, defaultApn,
-                             SMSSecurePreferences.getUseCustomMmsc(context),
-                             SMSSecurePreferences.getUseCustomMmscProxy(context),
-                             SMSSecurePreferences.getUseCustomMmscProxyPort(context),
-                             SMSSecurePreferences.getUseCustomMmscUsername(context),
-                             SMSSecurePreferences.getUseCustomMmscPassword(context));
+                             SilencePreferences.getUseCustomMmsc(context),
+                             SilencePreferences.getUseCustomMmscProxy(context),
+                             SilencePreferences.getUseCustomMmscProxyPort(context),
+                             SilencePreferences.getUseCustomMmscUsername(context),
+                             SilencePreferences.getUseCustomMmscPassword(context));
 
     if (TextUtils.isEmpty(result.getMmsc())) return Optional.absent();
     else                                     return Optional.of(result);

--- a/src/org/smssecure/smssecure/database/CanonicalAddressDatabase.java
+++ b/src/org/smssecure/smssecure/database/CanonicalAddressDatabase.java
@@ -34,7 +34,7 @@ import com.google.i18n.phonenumbers.ShortNumberInfo;
 
 import org.smssecure.smssecure.util.GroupUtil;
 import org.smssecure.smssecure.util.ShortCodeUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.VisibleForTesting;
 import org.whispersystems.textsecure.api.util.InvalidNumberException;
 import org.whispersystems.textsecure.api.util.PhoneNumberFormatter;
@@ -149,8 +149,8 @@ public class CanonicalAddressDatabase {
     try {
       long canonicalAddressId;
 
-      if (isNumberAddress(address) && SMSSecurePreferences.isPushRegistered(context)) {
-        String localNumber = SMSSecurePreferences.getLocalNumber(context);
+      if (isNumberAddress(address) && SilencePreferences.isPushRegistered(context)) {
+        String localNumber = SilencePreferences.getLocalNumber(context);
 
         if (!ShortCodeUtil.isShortCode(localNumber, address)) {
           address = PhoneNumberFormatter.formatNumber(address, localNumber);

--- a/src/org/smssecure/smssecure/database/DatabaseFactory.java
+++ b/src/org/smssecure/smssecure/database/DatabaseFactory.java
@@ -207,9 +207,9 @@ public class DatabaseFactory {
     db.beginTransaction();
 
     if (fromVersion < DatabaseUpgradeActivity.NO_MORE_KEY_EXCHANGE_PREFIX_VERSION) {
-      String KEY_EXCHANGE             = "?SMSSecureKeyExchange";
-      String PROCESSED_KEY_EXCHANGE   = "?SMSSecureKeyExchangd";
-      String STALE_KEY_EXCHANGE       = "?SMSSecureKeyExchangs";
+      String KEY_EXCHANGE             = "?SilenceKeyExchange";
+      String PROCESSED_KEY_EXCHANGE   = "?SilenceKeyExchangd";
+      String STALE_KEY_EXCHANGE       = "?SilenceKeyExchangs";
       int ROW_LIMIT                   = 500;
 
       MasterCipher masterCipher = new MasterCipher(masterSecret);
@@ -564,12 +564,12 @@ public class DatabaseFactory {
       }
 
       if (oldVersion < INTRODUCED_NEW_TYPES_VERSION) {
-        String KEY_EXCHANGE             = "?SMSSecureKeyExchange";
-        String SYMMETRIC_ENCRYPT        = "?SMSSecureLocalEncrypt";
-        String ASYMMETRIC_ENCRYPT       = "?SMSSecureAsymmetricEncrypt";
-        String ASYMMETRIC_LOCAL_ENCRYPT = "?SMSSecureAsymmetricLocalEncrypt";
-        String PROCESSED_KEY_EXCHANGE   = "?SMSSecureKeyExchangd";
-        String STALE_KEY_EXCHANGE       = "?SMSSecureKeyExchangs";
+        String KEY_EXCHANGE             = "?SilenceKeyExchange";
+        String SYMMETRIC_ENCRYPT        = "?SilenceLocalEncrypt";
+        String ASYMMETRIC_ENCRYPT       = "?SilenceAsymmetricEncrypt";
+        String ASYMMETRIC_LOCAL_ENCRYPT = "?SilenceAsymmetricLocalEncrypt";
+        String PROCESSED_KEY_EXCHANGE   = "?SilenceKeyExchangd";
+        String STALE_KEY_EXCHANGE       = "?SilenceKeyExchangs";
 
         // SMS Updates
         db.execSQL("UPDATE sms SET type = ? WHERE type = ?", new String[] {20L+"", 1L+""});

--- a/src/org/smssecure/smssecure/database/EncryptedBackupExporter.java
+++ b/src/org/smssecure/smssecure/database/EncryptedBackupExporter.java
@@ -42,7 +42,7 @@ public class EncryptedBackupExporter {
 
   private static String getExportDirectoryPath() {
     File sdDirectory  = Environment.getExternalStorageDirectory();
-    return sdDirectory.getAbsolutePath() + File.separator + "SMSSecureExport";
+    return sdDirectory.getAbsolutePath() + File.separator + "SilenceExport";
   }
 
   private static void verifyExternalStorageForExport() throws NoExternalStorageException {

--- a/src/org/smssecure/smssecure/database/GroupDatabase.java
+++ b/src/org/smssecure/smssecure/database/GroupDatabase.java
@@ -16,7 +16,7 @@ import org.smssecure.smssecure.recipients.RecipientFormattingException;
 import org.smssecure.smssecure.recipients.Recipients;
 import org.smssecure.smssecure.util.BitmapUtil;
 import org.smssecure.smssecure.util.GroupUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Util;
 
 import java.io.IOException;
@@ -87,7 +87,7 @@ public class GroupDatabase extends Database {
   }
 
   public Recipients getGroupMembers(byte[] groupId, boolean includeSelf) {
-    String          localNumber = SMSSecurePreferences.getLocalNumber(context);
+    String          localNumber = SilencePreferences.getLocalNumber(context);
     List<String>    members     = getCurrentMembers(groupId);
     List<Recipient> recipients  = new LinkedList<>();
 

--- a/src/org/smssecure/smssecure/database/MmsDatabase.java
+++ b/src/org/smssecure/smssecure/database/MmsDatabase.java
@@ -59,7 +59,7 @@ import org.smssecure.smssecure.util.GroupUtil;
 import org.smssecure.smssecure.util.InvalidNumberException;
 import org.smssecure.smssecure.util.JsonUtils;
 import org.smssecure.smssecure.util.ServiceUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Util;
 import org.whispersystems.jobqueue.JobManager;
 import org.whispersystems.libaxolotl.InvalidMessageException;
@@ -222,8 +222,8 @@ public class MmsDatabase extends MessagingDatabase {
 
     group.add(retrieved.getAddresses().getFrom());
 
-    if (SMSSecurePreferences.isPushRegistered(context)) {
-      localNumber = SMSSecurePreferences.getLocalNumber(context);
+    if (SilencePreferences.isPushRegistered(context)) {
+      localNumber = SilencePreferences.getLocalNumber(context);
     } else {
       localNumber = ServiceUtil.getTelephonyManager(context).getLine1Number();
     }

--- a/src/org/smssecure/smssecure/database/PlaintextBackupExporter.java
+++ b/src/org/smssecure/smssecure/database/PlaintextBackupExporter.java
@@ -26,7 +26,7 @@ public class PlaintextBackupExporter {
 
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
-    return sdDirectory.getAbsolutePath() + File.separator + "SMSSecurePlaintextBackup.xml";
+    return sdDirectory.getAbsolutePath() + File.separator + "SilencePlaintextBackup.xml";
   }
 
   private static void exportPlaintext(Context context, MasterSecret masterSecret)

--- a/src/org/smssecure/smssecure/database/PlaintextBackupImporter.java
+++ b/src/org/smssecure/smssecure/database/PlaintextBackupImporter.java
@@ -40,7 +40,7 @@ public class PlaintextBackupImporter {
 
   private static String getPlaintextExportDirectoryPath() throws NoExternalStorageException {
     File sdDirectory = Environment.getExternalStorageDirectory();
-    String[] files = {"SMSSecurePlaintextBackup.xml", "TextSecurePlaintextBackup.xml"};
+    String[] files = {"SilencePlaintextBackup.xml", "TextSecurePlaintextBackup.xml", "SMSSecurePlaintextBackup.xml", "SignalPlaintextBackup.xml"};
     String path;
 
     for (String s : files){

--- a/src/org/smssecure/smssecure/database/XmlBackup.java
+++ b/src/org/smssecure/smssecure/database/XmlBackup.java
@@ -144,7 +144,7 @@ public class XmlBackup {
   public static class Writer {
 
     private static final String  XML_HEADER      = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\" ?>";
-    private static final String  CREATED_BY      = "<!-- File Created By SMSSecure -->";
+    private static final String  CREATED_BY      = "<!-- File Created By Silence -->";
     private static final String  OPEN_TAG_SMSES  = "<smses count=\"%d\">";
     private static final String  CLOSE_TAG_SMSES = "</smses>";
     private static final String  OPEN_TAG_SMS    = " <sms ";

--- a/src/org/smssecure/smssecure/database/model/MessageRecord.java
+++ b/src/org/smssecure/smssecure/database/model/MessageRecord.java
@@ -30,7 +30,7 @@ import org.smssecure.smssecure.database.documents.IdentityKeyMismatch;
 import org.smssecure.smssecure.protocol.AutoInitiate;
 import org.smssecure.smssecure.recipients.Recipient;
 import org.smssecure.smssecure.recipients.Recipients;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.GroupUtil;
 
 import java.util.List;
@@ -112,7 +112,7 @@ public abstract class MessageRecord extends DisplayRecord {
   }
 
   public long getTimestamp() {
-    if (SMSSecurePreferences.showSentTime(context)) return getDateSent();
+    if (SilencePreferences.showSentTime(context)) return getDateSent();
     else                                            return getDateReceived();
   }
 

--- a/src/org/smssecure/smssecure/jobs/MmsDownloadJob.java
+++ b/src/org/smssecure/smssecure/jobs/MmsDownloadJob.java
@@ -11,7 +11,7 @@ import org.smssecure.smssecure.attachments.Attachment;
 import org.smssecure.smssecure.attachments.UriAttachment;
 import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.crypto.MmsCipher;
-import org.smssecure.smssecure.crypto.storage.SMSSecureAxolotlStore;
+import org.smssecure.smssecure.crypto.storage.SilenceAxolotlStore;
 import org.smssecure.smssecure.database.AttachmentDatabase;
 import org.smssecure.smssecure.database.DatabaseFactory;
 import org.smssecure.smssecure.database.MmsDatabase;
@@ -118,7 +118,7 @@ public class MmsDownloadJob extends MasterSecretJob {
       }
 
       if (retrieveConf.getSubject() != null && WirePrefix.isEncryptedMmsSubject(retrieveConf.getSubject().getString())) {
-        MmsCipher    mmsCipher    = new MmsCipher(new SMSSecureAxolotlStore(context, masterSecret));
+        MmsCipher    mmsCipher    = new MmsCipher(new SilenceAxolotlStore(context, masterSecret));
         RetrieveConf plaintextPdu = (RetrieveConf) mmsCipher.decrypt(context, retrieveConf);
 
         storeRetrievedMms(masterSecret, contentLocation, messageId, threadId, plaintextPdu, true, notification.get().second);

--- a/src/org/smssecure/smssecure/jobs/MmsSendJob.java
+++ b/src/org/smssecure/smssecure/jobs/MmsSendJob.java
@@ -7,7 +7,7 @@ import android.util.Log;
 import org.smssecure.smssecure.attachments.Attachment;
 import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.crypto.MmsCipher;
-import org.smssecure.smssecure.crypto.storage.SMSSecureAxolotlStore;
+import org.smssecure.smssecure.crypto.storage.SilenceAxolotlStore;
 import org.smssecure.smssecure.database.DatabaseFactory;
 import org.smssecure.smssecure.database.MmsDatabase;
 import org.smssecure.smssecure.database.NoSuchMessageException;
@@ -161,7 +161,7 @@ public class MmsSendJob extends SendJob {
       throws InsecureFallbackApprovalException, UndeliverableMessageException
   {
     try {
-      MmsCipher cipher = new MmsCipher(new SMSSecureAxolotlStore(context, masterSecret));
+      MmsCipher cipher = new MmsCipher(new SilenceAxolotlStore(context, masterSecret));
       return cipher.encrypt(context, pdu);
     } catch (NoSessionException e) {
       throw new InsecureFallbackApprovalException(e);

--- a/src/org/smssecure/smssecure/jobs/SendJob.java
+++ b/src/org/smssecure/smssecure/jobs/SendJob.java
@@ -5,7 +5,6 @@ import android.support.annotation.NonNull;
 
 import org.smssecure.smssecure.BuildConfig;
 import org.smssecure.smssecure.attachments.Attachment;
-import org.smssecure.smssecure.SMSSecureExpiredException;
 import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.database.AttachmentDatabase;
 import org.smssecure.smssecure.database.DatabaseFactory;

--- a/src/org/smssecure/smssecure/jobs/SmsDecryptJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsDecryptJob.java
@@ -9,7 +9,7 @@ import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.crypto.MasterSecretUtil;
 import org.smssecure.smssecure.crypto.SecurityEvent;
 import org.smssecure.smssecure.crypto.SmsCipher;
-import org.smssecure.smssecure.crypto.storage.SMSSecureAxolotlStore;
+import org.smssecure.smssecure.crypto.storage.SilenceAxolotlStore;
 import org.smssecure.smssecure.database.DatabaseFactory;
 import org.smssecure.smssecure.database.EncryptingSmsDatabase;
 import org.smssecure.smssecure.database.NoSuchMessageException;
@@ -24,7 +24,7 @@ import org.smssecure.smssecure.sms.IncomingPreKeyBundleMessage;
 import org.smssecure.smssecure.sms.IncomingTextMessage;
 import org.smssecure.smssecure.sms.MessageSender;
 import org.smssecure.smssecure.sms.OutgoingKeyExchangeMessage;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.whispersystems.jobqueue.JobParameters;
 import org.whispersystems.libaxolotl.DuplicateMessageException;
 import org.whispersystems.libaxolotl.InvalidMessageException;
@@ -109,7 +109,7 @@ public class SmsDecryptJob extends MasterSecretJob {
       InvalidMessageException, LegacyMessageException
   {
     EncryptingSmsDatabase database  = DatabaseFactory.getEncryptingSmsDatabase(context);
-    SmsCipher             cipher    = new SmsCipher(new SMSSecureAxolotlStore(context, masterSecret));
+    SmsCipher             cipher    = new SmsCipher(new SilenceAxolotlStore(context, masterSecret));
     IncomingTextMessage   plaintext = cipher.decrypt(context, message);
 
     database.updateMessageBody(masterSecret, messageId, plaintext.getMessageBody());
@@ -125,7 +125,7 @@ public class SmsDecryptJob extends MasterSecretJob {
     EncryptingSmsDatabase database = DatabaseFactory.getEncryptingSmsDatabase(context);
 
     try {
-      SmsCipher                smsCipher = new SmsCipher(new SMSSecureAxolotlStore(context, masterSecret));
+      SmsCipher                smsCipher = new SmsCipher(new SilenceAxolotlStore(context, masterSecret));
       IncomingEncryptedMessage plaintext = smsCipher.decrypt(context, message);
 
       database.updateBundleMessageBody(masterSecret, messageId, plaintext.getMessageBody());
@@ -144,9 +144,9 @@ public class SmsDecryptJob extends MasterSecretJob {
   {
     EncryptingSmsDatabase database = DatabaseFactory.getEncryptingSmsDatabase(context);
 
-    if (SMSSecurePreferences.isAutoRespondKeyExchangeEnabled(context) || manualOverride) {
+    if (SilencePreferences.isAutoRespondKeyExchangeEnabled(context) || manualOverride) {
       try {
-        SmsCipher                  cipher   = new SmsCipher(new SMSSecureAxolotlStore(context, masterSecret));
+        SmsCipher                  cipher   = new SmsCipher(new SilenceAxolotlStore(context, masterSecret));
         OutgoingKeyExchangeMessage response = cipher.process(context, message);
 
         database.markAsProcessedKeyExchange(messageId);

--- a/src/org/smssecure/smssecure/jobs/SmsSendJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsSendJob.java
@@ -11,7 +11,7 @@ import android.util.Log;
 
 import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.crypto.SmsCipher;
-import org.smssecure.smssecure.crypto.storage.SMSSecureAxolotlStore;
+import org.smssecure.smssecure.crypto.storage.SilenceAxolotlStore;
 import org.smssecure.smssecure.database.DatabaseFactory;
 import org.smssecure.smssecure.database.EncryptingSmsDatabase;
 import org.smssecure.smssecure.database.NoSuchMessageException;
@@ -28,7 +28,7 @@ import org.smssecure.smssecure.sms.OutgoingTextMessage;
 import org.smssecure.smssecure.transport.InsecureFallbackApprovalException;
 import org.smssecure.smssecure.transport.UndeliverableMessageException;
 import org.smssecure.smssecure.util.NumberUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.whispersystems.jobqueue.JobParameters;
 import org.whispersystems.libaxolotl.NoSessionException;
 
@@ -186,7 +186,7 @@ public class SmsSendJob extends SendJob {
       throws InsecureFallbackApprovalException
   {
     try {
-      return new SmsCipher(new SMSSecureAxolotlStore(context, masterSecret)).encrypt(message);
+      return new SmsCipher(new SilenceAxolotlStore(context, masterSecret)).encrypt(message);
     } catch (NoSessionException e) {
       throw new InsecureFallbackApprovalException(e);
     }
@@ -207,7 +207,7 @@ public class SmsSendJob extends SendJob {
   }
 
   private ArrayList<PendingIntent> constructDeliveredIntents(long messageId, long type, ArrayList<String> messages) {
-    if (!SMSSecurePreferences.isSmsDeliveryReportsEnabled(context)) {
+    if (!SilencePreferences.isSmsDeliveryReportsEnabled(context)) {
       return null;
     }
 
@@ -262,7 +262,7 @@ public class SmsSendJob extends SendJob {
                                                  .withRetryCount(15)
                                                  .withGroupId(name);
 
-    if (SMSSecurePreferences.isWifiSmsEnabled(context)) {
+    if (SilencePreferences.isWifiSmsEnabled(context)) {
       builder.withRequirement(new NetworkOrServiceRequirement(context));
     } else {
       builder.withRequirement(new ServiceRequirement(context));

--- a/src/org/smssecure/smssecure/jobs/SmsSentJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsSentJob.java
@@ -8,7 +8,7 @@ import android.util.Log;
 import org.smssecure.smssecure.ApplicationContext;
 import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.crypto.SecurityEvent;
-import org.smssecure.smssecure.crypto.storage.SMSSecureSessionStore;
+import org.smssecure.smssecure.crypto.storage.SilenceSessionStore;
 import org.smssecure.smssecure.database.DatabaseFactory;
 import org.smssecure.smssecure.database.EncryptingSmsDatabase;
 import org.smssecure.smssecure.database.NoSuchMessageException;
@@ -16,7 +16,7 @@ import org.smssecure.smssecure.database.model.SmsMessageRecord;
 import org.smssecure.smssecure.jobs.requirements.MasterSecretRequirement;
 import org.smssecure.smssecure.notifications.MessageNotifier;
 import org.smssecure.smssecure.service.SmsDeliveryListener;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.whispersystems.jobqueue.JobParameters;
 import org.whispersystems.libaxolotl.state.SessionStore;
 
@@ -74,7 +74,7 @@ public class SmsSentJob extends MasterSecretJob {
       SmsMessageRecord      record        = database.getMessage(masterSecret, messageId);
       String                recipientName = (record.getIndividualRecipient().getName() == null ? record.getIndividualRecipient().getNumber() : record.getIndividualRecipient().getName());
 
-      if (!record.isDelivered() && SMSSecurePreferences.isSmsDeliveryReportsToastEnabled(context)){
+      if (!record.isDelivered() && SilencePreferences.isSmsDeliveryReportsToastEnabled(context)){
         MessageNotifier.sendDeliveryToast(context, recipientName);
       }
       DatabaseFactory.getEncryptingSmsDatabase(context).markAsReceived(messageId);
@@ -94,7 +94,7 @@ public class SmsSentJob extends MasterSecretJob {
 
           if (record != null && record.isEndSession()) {
             Log.w(TAG, "Ending session...");
-            SessionStore sessionStore = new SMSSecureSessionStore(context, masterSecret);
+            SessionStore sessionStore = new SilenceSessionStore(context, masterSecret);
             sessionStore.deleteAllSessions(record.getIndividualRecipient().getNumber());
             SecurityEvent.broadcastSecurityUpdateEvent(context, record.getThreadId());
           }

--- a/src/org/smssecure/smssecure/jobs/TrimThreadJob.java
+++ b/src/org/smssecure/smssecure/jobs/TrimThreadJob.java
@@ -20,7 +20,7 @@ import android.content.Context;
 import android.util.Log;
 
 import org.smssecure.smssecure.database.DatabaseFactory;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.whispersystems.jobqueue.Job;
 import org.whispersystems.jobqueue.JobParameters;
 
@@ -44,8 +44,8 @@ public class TrimThreadJob extends Job {
 
   @Override
   public void onRun() {
-    boolean trimmingEnabled   = SMSSecurePreferences.isThreadLengthTrimmingEnabled(context);
-    int     threadLengthLimit = SMSSecurePreferences.getThreadTrimLength(context);
+    boolean trimmingEnabled   = SilencePreferences.isThreadLengthTrimmingEnabled(context);
+    int     threadLengthLimit = SilencePreferences.getThreadTrimLength(context);
 
     if (!trimmingEnabled)
       return;

--- a/src/org/smssecure/smssecure/jobs/requirements/MediaNetworkRequirement.java
+++ b/src/org/smssecure/smssecure/jobs/requirements/MediaNetworkRequirement.java
@@ -6,7 +6,7 @@ import android.net.NetworkInfo;
 import android.util.Log;
 
 import org.smssecure.smssecure.util.TelephonyUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.whispersystems.jobqueue.dependencies.ContextDependent;
 import org.whispersystems.jobqueue.requirements.Requirement;
 
@@ -33,10 +33,10 @@ public class MediaNetworkRequirement implements Requirement, ContextDependent {
     if (!automatic){
       return true;
     } else if (TelephonyUtil.isConnectedRoaming(context)) {
-      return SMSSecurePreferences.isMediaDownloadAllowed(context) &&
-             SMSSecurePreferences.isRoamingMediaDownloadAllowed(context);
+      return SilencePreferences.isMediaDownloadAllowed(context) &&
+             SilencePreferences.isRoamingMediaDownloadAllowed(context);
     } else {
-      return SMSSecurePreferences.isMediaDownloadAllowed(context);
+      return SilencePreferences.isMediaDownloadAllowed(context);
     }
   }
 }

--- a/src/org/smssecure/smssecure/mms/LegacyMmsConnection.java
+++ b/src/org/smssecure/smssecure/mms/LegacyMmsConnection.java
@@ -40,7 +40,7 @@ import org.smssecure.smssecure.database.ApnDatabase;
 import org.smssecure.smssecure.util.Conversions;
 import org.smssecure.smssecure.util.ServiceUtil;
 import org.smssecure.smssecure.util.TelephonyUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Util;
 import org.whispersystems.libaxolotl.util.guava.Optional;
 
@@ -178,7 +178,7 @@ public abstract class LegacyMmsConnection {
     return HttpClients.custom()
                       .setConnectionReuseStrategy(new NoConnectionReuseStrategyHC4())
                       .setRedirectStrategy(new LaxRedirectStrategy())
-                      .setUserAgent(SMSSecurePreferences.getMmsUserAgent(context, USER_AGENT))
+                      .setUserAgent(SilencePreferences.getMmsUserAgent(context, USER_AGENT))
                       .setConnectionManager(new BasicHttpClientConnectionManager())
                       .setDefaultRequestConfig(config)
                       .setDefaultCredentialsProvider(credsProvider)

--- a/src/org/smssecure/smssecure/mms/SilenceGlideModule.java
+++ b/src/org/smssecure/smssecure/mms/SilenceGlideModule.java
@@ -14,7 +14,7 @@ import org.smssecure.smssecure.mms.DecryptableStreamUriLoader.DecryptableUri;
 
 import java.io.InputStream;
 
-public class SMSSecureGlideModule implements GlideModule {
+public class SilenceGlideModule implements GlideModule {
   @Override
   public void applyOptions(Context context, GlideBuilder builder) {
     builder.setDiskCache(new NoopDiskCacheFactory());

--- a/src/org/smssecure/smssecure/notifications/AbstractNotificationBuilder.java
+++ b/src/org/smssecure/smssecure/notifications/AbstractNotificationBuilder.java
@@ -13,7 +13,7 @@ import android.text.TextUtils;
 import org.smssecure.smssecure.database.RecipientPreferenceDatabase;
 import org.smssecure.smssecure.preferences.NotificationPrivacyPreference;
 import org.smssecure.smssecure.recipients.Recipient;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Util;
 
 public abstract class AbstractNotificationBuilder extends NotificationCompat.Builder {
@@ -38,8 +38,8 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
   }
 
   public void setAudibleAlarms(@Nullable Uri ringtone, RecipientPreferenceDatabase.VibrateState vibrate) {
-    String defaultRingtoneName   = SMSSecurePreferences.getNotificationRingtone(context);
-    boolean defaultVibrate       = SMSSecurePreferences.isNotificationVibrateEnabled(context);
+    String defaultRingtoneName   = SilencePreferences.getNotificationRingtone(context);
+    boolean defaultVibrate       = SilencePreferences.isNotificationVibrateEnabled(context);
 
     if      (ringtone != null)                        setSound(ringtone);
     else if (!TextUtils.isEmpty(defaultRingtoneName)) setSound(Uri.parse(defaultRingtoneName));
@@ -53,9 +53,9 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
   }
 
   public void setVisualAlarms() {
-    String ledColor              = SMSSecurePreferences.getNotificationLedColor(context);
-    String ledBlinkPattern       = SMSSecurePreferences.getNotificationLedPattern(context);
-    String ledBlinkPatternCustom = SMSSecurePreferences.getNotificationLedPatternCustom(context);
+    String ledColor              = SilencePreferences.getNotificationLedColor(context);
+    String ledBlinkPattern       = SilencePreferences.getNotificationLedPattern(context);
+    String ledBlinkPatternCustom = SilencePreferences.getNotificationLedPatternCustom(context);
     String[] blinkPatternArray   = parseBlinkPattern(ledBlinkPattern, ledBlinkPatternCustom);
 
     if (!ledColor.equals("none")) {

--- a/src/org/smssecure/smssecure/notifications/MessageNotifier.java
+++ b/src/org/smssecure/smssecure/notifications/MessageNotifier.java
@@ -54,7 +54,7 @@ import org.smssecure.smssecure.recipients.RecipientFactory;
 import org.smssecure.smssecure.recipients.Recipients;
 import org.smssecure.smssecure.service.KeyCachingService;
 import org.smssecure.smssecure.util.SpanUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 import java.util.List;
 import java.util.ListIterator;
@@ -125,14 +125,14 @@ public class MessageNotifier {
       intent.putExtra(ConversationActivity.THREAD_ID_EXTRA, threadId);
       intent.setData((Uri.parse("custom://" + System.currentTimeMillis())));
 
-      FailedNotificationBuilder builder = new FailedNotificationBuilder(context, SMSSecurePreferences.getNotificationPrivacy(context), intent);
+      FailedNotificationBuilder builder = new FailedNotificationBuilder(context, SilencePreferences.getNotificationPrivacy(context), intent);
       ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
         .notify((int)threadId, builder.build());
     }
   }
 
   public static void updateNotificationWithFlags(Context context, MasterSecret masterSecret, int flags) {
-    if (!SMSSecurePreferences.isNotificationsEnabled(context)) {
+    if (!SilencePreferences.isNotificationsEnabled(context)) {
       return;
     }
 
@@ -154,7 +154,7 @@ public class MessageNotifier {
       threads.setRead(threadId);
     }
 
-    if (!SMSSecurePreferences.isNotificationsEnabled(context) ||
+    if (!SilencePreferences.isNotificationsEnabled(context) ||
         (recipients != null && recipients.isMuted()))
     {
       return;
@@ -221,7 +221,7 @@ public class MessageNotifier {
       return;
     }
 
-    SingleRecipientNotificationBuilder builder       = new SingleRecipientNotificationBuilder(context, masterSecret, SMSSecurePreferences.getNotificationPrivacy(context));
+    SingleRecipientNotificationBuilder builder       = new SingleRecipientNotificationBuilder(context, masterSecret, SilencePreferences.getNotificationPrivacy(context));
     List<NotificationItem>             notifications = notificationState.getNotifications();
     Recipients                         recipients    = notifications.get(0).getRecipients();
 
@@ -261,7 +261,7 @@ public class MessageNotifier {
                                                      NotificationState notificationState,
                                                      int flags)
   {
-    MultipleRecipientNotificationBuilder builder       = new MultipleRecipientNotificationBuilder(context, SMSSecurePreferences.getNotificationPrivacy(context));
+    MultipleRecipientNotificationBuilder builder       = new MultipleRecipientNotificationBuilder(context, SilencePreferences.getNotificationPrivacy(context));
     List<NotificationItem>               notifications = notificationState.getNotifications();
 
     builder.setMessageCount(notificationState.getMessageCount(), notificationState.getThreadCount());
@@ -290,14 +290,14 @@ public class MessageNotifier {
   }
 
   private static void sendInThreadNotification(Context context, Recipients recipients) {
-    if (!SMSSecurePreferences.isInThreadNotifications(context)) {
+    if (!SilencePreferences.isInThreadNotifications(context)) {
       return;
     }
 
     Uri uri = recipients != null ? recipients.getRingtone() : null;
 
     if (uri == null) {
-      String ringtone = SMSSecurePreferences.getNotificationRingtone(context);
+      String ringtone = SilencePreferences.getNotificationRingtone(context);
 
       if (ringtone == null) {
         Log.w(TAG, "ringtone preference was null.");
@@ -381,7 +381,7 @@ public class MessageNotifier {
   }
 
   private static void scheduleReminder(Context context, int count) {
-    if (count >= SMSSecurePreferences.getRepeatAlertsCount(context)) {
+    if (count >= SilencePreferences.getRepeatAlertsCount(context)) {
       return;
     }
 

--- a/src/org/smssecure/smssecure/notifications/MultipleRecipientNotificationBuilder.java
+++ b/src/org/smssecure/smssecure/notifications/MultipleRecipientNotificationBuilder.java
@@ -24,7 +24,7 @@ public class MultipleRecipientNotificationBuilder extends AbstractNotificationBu
   public MultipleRecipientNotificationBuilder(Context context, NotificationPrivacyPreference privacy) {
     super(context, privacy);
 
-    setColor(context.getResources().getColor(R.color.smssecure_primary));
+    setColor(context.getResources().getColor(R.color.silence_primary));
     setSmallIcon(R.drawable.icon_notification);
     setContentTitle(context.getString(R.string.app_name));
     setContentIntent(PendingIntent.getActivity(context, 0, new Intent(context, ConversationListActivity.class), 0));

--- a/src/org/smssecure/smssecure/notifications/SingleRecipientNotificationBuilder.java
+++ b/src/org/smssecure/smssecure/notifications/SingleRecipientNotificationBuilder.java
@@ -49,7 +49,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     this.masterSecret = masterSecret;
 
     setSmallIcon(R.drawable.icon_notification);
-    setColor(context.getResources().getColor(R.color.smssecure_primary));
+    setColor(context.getResources().getColor(R.color.silence_primary));
     setPriority(NotificationCompat.PRIORITY_HIGH);
     setCategory(NotificationCompat.CATEGORY_MESSAGE);
     setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(MessageNotifier.DeleteReceiver.DELETE_REMINDER_ACTION), 0));
@@ -67,7 +67,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
                             .asDrawable(context, recipients.getColor()
                                                           .toConversationColor(context)));
     } else {
-      setContentTitle(context.getString(R.string.SingleRecipientNotificationBuilder_smssecure));
+      setContentTitle(context.getString(R.string.SingleRecipientNotificationBuilder_silence));
       setLargeIcon(Recipient.getUnknownRecipient()
                             .getContactPhoto()
                             .asDrawable(context, Recipient.getUnknownRecipient()

--- a/src/org/smssecure/smssecure/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/smssecure/smssecure/preferences/AdvancedPreferenceFragment.java
@@ -15,7 +15,7 @@ import org.smssecure.smssecure.LogSubmitActivity;
 import org.smssecure.smssecure.R;
 import org.smssecure.smssecure.contacts.ContactAccessor;
 import org.smssecure.smssecure.crypto.MasterSecret;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment {
   private static final String TAG = AdvancedPreferenceFragment.class.getSimpleName();
@@ -30,8 +30,8 @@ public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment {
     this.findPreference(SUBMIT_DEBUG_LOG_PREF)
       .setOnPreferenceClickListener(new SubmitDebugLogListener());
 
-    this.findPreference(SMSSecurePreferences.ENTER_KEY_TYPE).setOnPreferenceChangeListener(new ListSummaryListener());
-    initializeListSummary((ListPreference) this.findPreference(SMSSecurePreferences.ENTER_KEY_TYPE));
+    this.findPreference(SilencePreferences.ENTER_KEY_TYPE).setOnPreferenceChangeListener(new ListSummaryListener());
+    initializeListSummary((ListPreference) this.findPreference(SilencePreferences.ENTER_KEY_TYPE));
   }
 
   @Override

--- a/src/org/smssecure/smssecure/preferences/AppProtectionPreferenceFragment.java
+++ b/src/org/smssecure/smssecure/preferences/AppProtectionPreferenceFragment.java
@@ -23,7 +23,7 @@ import org.smssecure.smssecure.R;
 import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.crypto.MasterSecretUtil;
 import org.smssecure.smssecure.service.KeyCachingService;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 import java.util.concurrent.TimeUnit;
 
@@ -42,9 +42,9 @@ public class AppProtectionPreferenceFragment extends PreferenceFragment {
     masterSecret      = getArguments().getParcelable("master_secret");
     disablePassphrase = (CheckBoxPreference) this.findPreference("pref_enable_passphrase_temporary");
 
-    this.findPreference(SMSSecurePreferences.CHANGE_PASSPHRASE_PREF)
+    this.findPreference(SilencePreferences.CHANGE_PASSPHRASE_PREF)
         .setOnPreferenceClickListener(new ChangePassphraseClickListener());
-    this.findPreference(SMSSecurePreferences.PASSPHRASE_TIMEOUT_INTERVAL_PREF)
+    this.findPreference(SilencePreferences.PASSPHRASE_TIMEOUT_INTERVAL_PREF)
         .setOnPreferenceClickListener(new PassphraseIntervalClickListener());
     this.findPreference(PREFERENCE_CATEGORY_BLOCKED)
         .setOnPreferenceClickListener(new BlockedContactsClickListener());
@@ -60,12 +60,12 @@ public class AppProtectionPreferenceFragment extends PreferenceFragment {
     initializePlatformSpecificOptions();
     initializeTimeoutSummary();
 
-    disablePassphrase.setChecked(!SMSSecurePreferences.isPasswordDisabled(getActivity()));
+    disablePassphrase.setChecked(!SilencePreferences.isPasswordDisabled(getActivity()));
   }
 
   private void initializePlatformSpecificOptions() {
     PreferenceScreen preferenceScreen         = getPreferenceScreen();
-    Preference       screenSecurityPreference = findPreference(SMSSecurePreferences.SCREEN_SECURITY_PREF);
+    Preference       screenSecurityPreference = findPreference(SilencePreferences.SCREEN_SECURITY_PREF);
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH &&
         screenSecurityPreference != null) {
@@ -74,8 +74,8 @@ public class AppProtectionPreferenceFragment extends PreferenceFragment {
   }
 
   private void initializeTimeoutSummary() {
-    int timeoutMinutes = SMSSecurePreferences.getPassphraseTimeoutInterval(getActivity());
-    this.findPreference(SMSSecurePreferences.PASSPHRASE_TIMEOUT_INTERVAL_PREF)
+    int timeoutMinutes = SilencePreferences.getPassphraseTimeoutInterval(getActivity());
+    this.findPreference(SilencePreferences.PASSPHRASE_TIMEOUT_INTERVAL_PREF)
         .setSummary(getResources().getQuantityString(R.plurals.AppProtectionPreferenceFragment_minutes, timeoutMinutes, timeoutMinutes));
   }
 
@@ -126,7 +126,7 @@ public class AppProtectionPreferenceFragment extends PreferenceFragment {
                                     minutes                         +
                                     (int)TimeUnit.SECONDS.toMinutes(seconds), 1);
 
-      SMSSecurePreferences.setPassphraseTimeoutInterval(getActivity(), timeoutMinutes);
+      SilencePreferences.setPassphraseTimeoutInterval(getActivity(), timeoutMinutes);
       initializeTimeoutSummary();
     }
   }
@@ -147,7 +147,7 @@ public class AppProtectionPreferenceFragment extends PreferenceFragment {
                                                           masterSecret,
                                                           MasterSecretUtil.UNENCRYPTED_PASSPHRASE);
 
-            SMSSecurePreferences.setPasswordDisabled(getActivity(), true);
+            SilencePreferences.setPasswordDisabled(getActivity(), true);
             ((CheckBoxPreference)preference).setChecked(false);
 
             Intent intent = new Intent(getActivity(), KeyCachingService.class);
@@ -171,14 +171,14 @@ public class AppProtectionPreferenceFragment extends PreferenceFragment {
     final String onRes               = context.getString(R.string.ApplicationPreferencesActivity_on);
     final String offRes              = context.getString(R.string.ApplicationPreferencesActivity_off);
 
-    if (SMSSecurePreferences.isPasswordDisabled(context)) {
-      if (SMSSecurePreferences.isScreenSecurityEnabled(context)) {
+    if (SilencePreferences.isPasswordDisabled(context)) {
+      if (SilencePreferences.isScreenSecurityEnabled(context)) {
         return context.getString(privacySummaryResId, offRes, onRes);
       } else {
         return context.getString(privacySummaryResId, offRes, offRes);
       }
     } else {
-      if (SMSSecurePreferences.isScreenSecurityEnabled(context)) {
+      if (SilencePreferences.isScreenSecurityEnabled(context)) {
         return context.getString(privacySummaryResId, onRes, onRes);
       } else {
         return context.getString(privacySummaryResId, onRes, offRes);

--- a/src/org/smssecure/smssecure/preferences/AppearancePreferenceFragment.java
+++ b/src/org/smssecure/smssecure/preferences/AppearancePreferenceFragment.java
@@ -6,7 +6,7 @@ import android.preference.ListPreference;
 
 import org.smssecure.smssecure.ApplicationPreferencesActivity;
 import org.smssecure.smssecure.R;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 import java.util.Arrays;
 
@@ -17,10 +17,10 @@ public class AppearancePreferenceFragment extends ListSummaryPreferenceFragment 
     super.onCreate(paramBundle);
     addPreferencesFromResource(R.xml.preferences_appearance);
 
-    this.findPreference(SMSSecurePreferences.THEME_PREF).setOnPreferenceChangeListener(new ListSummaryListener());
-    this.findPreference(SMSSecurePreferences.LANGUAGE_PREF).setOnPreferenceChangeListener(new ListSummaryListener());
-    initializeListSummary((ListPreference)findPreference(SMSSecurePreferences.THEME_PREF));
-    initializeListSummary((ListPreference)findPreference(SMSSecurePreferences.LANGUAGE_PREF));
+    this.findPreference(SilencePreferences.THEME_PREF).setOnPreferenceChangeListener(new ListSummaryListener());
+    this.findPreference(SilencePreferences.LANGUAGE_PREF).setOnPreferenceChangeListener(new ListSummaryListener());
+    initializeListSummary((ListPreference)findPreference(SilencePreferences.THEME_PREF));
+    initializeListSummary((ListPreference)findPreference(SilencePreferences.LANGUAGE_PREF));
   }
 
   @Override
@@ -47,8 +47,8 @@ public class AppearancePreferenceFragment extends ListSummaryPreferenceFragment 
     String[] themeEntries        = context.getResources().getStringArray(R.array.pref_theme_entries);
     String[] themeEntryValues    = context.getResources().getStringArray(R.array.pref_theme_values);
 
-    int langIndex  = Arrays.asList(languageEntryValues).indexOf(SMSSecurePreferences.getLanguage(context));
-    int themeIndex = Arrays.asList(themeEntryValues).indexOf(SMSSecurePreferences.getTheme(context));
+    int langIndex  = Arrays.asList(languageEntryValues).indexOf(SilencePreferences.getLanguage(context));
+    int themeIndex = Arrays.asList(themeEntryValues).indexOf(SilencePreferences.getTheme(context));
 
     if (langIndex == -1)  langIndex = 0;
     if (themeIndex == -1) themeIndex = 0;

--- a/src/org/smssecure/smssecure/preferences/ChatsPreferenceFragment.java
+++ b/src/org/smssecure/smssecure/preferences/ChatsPreferenceFragment.java
@@ -13,7 +13,7 @@ import android.util.Log;
 
 import org.smssecure.smssecure.ApplicationPreferencesActivity;
 import org.smssecure.smssecure.R;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Trimmer;
 
 import java.util.ArrayList;
@@ -28,9 +28,9 @@ public class ChatsPreferenceFragment extends PreferenceFragment {
     super.onCreate(paramBundle);
     addPreferencesFromResource(R.xml.preferences_chats);
 
-    findPreference(SMSSecurePreferences.THREAD_TRIM_NOW)
+    findPreference(SilencePreferences.THREAD_TRIM_NOW)
         .setOnPreferenceClickListener(new TrimNowClickListener());
-    findPreference(SMSSecurePreferences.THREAD_TRIM_LENGTH)
+    findPreference(SilencePreferences.THREAD_TRIM_LENGTH)
         .setOnPreferenceChangeListener(new TrimLengthValidationListener());
 
   }
@@ -44,7 +44,7 @@ public class ChatsPreferenceFragment extends PreferenceFragment {
   private class TrimNowClickListener implements Preference.OnPreferenceClickListener {
     @Override
     public boolean onPreferenceClick(Preference preference) {
-      final int threadLengthLimit = SMSSecurePreferences.getThreadTrimLength(getActivity());
+      final int threadLengthLimit = SilencePreferences.getThreadTrimLength(getActivity());
       AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
       builder.setTitle(R.string.ApplicationPreferencesActivity_delete_all_old_messages_now);
       builder.setMessage(getResources().getQuantityString(R.plurals.ApplicationPreferencesActivity_this_will_immediately_trim_all_conversations_to_the_d_most_recent_messages,
@@ -67,7 +67,7 @@ public class ChatsPreferenceFragment extends PreferenceFragment {
   private class TrimLengthValidationListener implements Preference.OnPreferenceChangeListener {
 
     public TrimLengthValidationListener() {
-      EditTextPreference preference = (EditTextPreference)findPreference(SMSSecurePreferences.THREAD_TRIM_LENGTH);
+      EditTextPreference preference = (EditTextPreference)findPreference(SilencePreferences.THREAD_TRIM_LENGTH);
       onPreferenceChange(preference, preference.getText());
     }
 

--- a/src/org/smssecure/smssecure/preferences/LedBlinkPatternListPreference.java
+++ b/src/org/smssecure/smssecure/preferences/LedBlinkPatternListPreference.java
@@ -30,7 +30,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.smssecure.smssecure.R;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 /**
  * List preference for LED blink pattern notification.
@@ -64,13 +64,13 @@ public class LedBlinkPatternListPreference extends ListPreference implements OnS
     super.onDialogClosed(positiveResult);
 
     if (positiveResult) {
-      String blinkPattern = SMSSecurePreferences.getNotificationLedPattern(context);
+      String blinkPattern = SilencePreferences.getNotificationLedPattern(context);
       if (blinkPattern.equals("custom")) showDialog();
     }
   }
 
   private void initializeSeekBarValues() {
-    String patternString  = SMSSecurePreferences.getNotificationLedPatternCustom(context);
+    String patternString  = SilencePreferences.getNotificationLedPatternCustom(context);
     String[] patternArray = patternString.split(",");
     seekBarOn.setProgress(Integer.parseInt(patternArray[0]));
     seekBarOff.setProgress(Integer.parseInt(patternArray[1]));
@@ -149,7 +149,7 @@ public class LedBlinkPatternListPreference extends ListPreference implements OnS
       String pattern   = seekBarOnLabel.getText() + "," + seekBarOffLabel.getText();
       dialogInProgress = false;
 
-      SMSSecurePreferences.setNotificationLedPatternCustom(context, pattern);
+      SilencePreferences.setNotificationLedPatternCustom(context, pattern);
       Toast.makeText(context, R.string.preferences__pref_led_blink_custom_pattern_set, Toast.LENGTH_LONG).show();
     }
 

--- a/src/org/smssecure/smssecure/preferences/MmsPreferencesFragment.java
+++ b/src/org/smssecure/smssecure/preferences/MmsPreferencesFragment.java
@@ -28,7 +28,7 @@ import org.smssecure.smssecure.components.CustomDefaultPreference;
 import org.smssecure.smssecure.database.ApnDatabase;
 import org.smssecure.smssecure.mms.LegacyMmsConnection;
 import org.smssecure.smssecure.util.TelephonyUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 import java.io.IOException;
 
@@ -73,25 +73,25 @@ public class MmsPreferencesFragment extends PreferenceFragment {
 
     @Override
     protected void onPostExecute(LegacyMmsConnection.Apn apnDefaults) {
-      ((CustomDefaultPreference)findPreference(SMSSecurePreferences.MMSC_HOST_PREF))
+      ((CustomDefaultPreference)findPreference(SilencePreferences.MMSC_HOST_PREF))
           .setValidator(new CustomDefaultPreference.UriValidator())
           .setDefaultValue(apnDefaults.getMmsc());
 
-      ((CustomDefaultPreference)findPreference(SMSSecurePreferences.MMSC_PROXY_HOST_PREF))
+      ((CustomDefaultPreference)findPreference(SilencePreferences.MMSC_PROXY_HOST_PREF))
           .setValidator(new CustomDefaultPreference.HostnameValidator())
           .setDefaultValue(apnDefaults.getProxy());
 
-      ((CustomDefaultPreference)findPreference(SMSSecurePreferences.MMSC_PROXY_PORT_PREF))
+      ((CustomDefaultPreference)findPreference(SilencePreferences.MMSC_PROXY_PORT_PREF))
           .setValidator(new CustomDefaultPreference.PortValidator())
           .setDefaultValue(apnDefaults.getPort());
 
-      ((CustomDefaultPreference)findPreference(SMSSecurePreferences.MMSC_USERNAME_PREF))
+      ((CustomDefaultPreference)findPreference(SilencePreferences.MMSC_USERNAME_PREF))
           .setDefaultValue(apnDefaults.getPort());
 
-      ((CustomDefaultPreference)findPreference(SMSSecurePreferences.MMSC_PASSWORD_PREF))
+      ((CustomDefaultPreference)findPreference(SilencePreferences.MMSC_PASSWORD_PREF))
           .setDefaultValue(apnDefaults.getPassword());
 
-      ((CustomDefaultPreference)findPreference(SMSSecurePreferences.MMS_USER_AGENT))
+      ((CustomDefaultPreference)findPreference(SilencePreferences.MMS_USER_AGENT))
           .setDefaultValue(LegacyMmsConnection.USER_AGENT);
     }
   }

--- a/src/org/smssecure/smssecure/preferences/NotificationsPreferenceFragment.java
+++ b/src/org/smssecure/smssecure/preferences/NotificationsPreferenceFragment.java
@@ -17,7 +17,7 @@ import org.smssecure.smssecure.ApplicationPreferencesActivity;
 import org.smssecure.smssecure.R;
 import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.notifications.MessageNotifier;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragment {
 
@@ -29,22 +29,22 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
     masterSecret = getArguments().getParcelable("master_secret");
     addPreferencesFromResource(R.xml.preferences_notifications);
 
-    this.findPreference(SMSSecurePreferences.LED_COLOR_PREF)
+    this.findPreference(SilencePreferences.LED_COLOR_PREF)
         .setOnPreferenceChangeListener(new ListSummaryListener());
-    this.findPreference(SMSSecurePreferences.LED_BLINK_PREF)
+    this.findPreference(SilencePreferences.LED_BLINK_PREF)
         .setOnPreferenceChangeListener(new ListSummaryListener());
-    this.findPreference(SMSSecurePreferences.RINGTONE_PREF)
+    this.findPreference(SilencePreferences.RINGTONE_PREF)
         .setOnPreferenceChangeListener(new RingtoneSummaryListener());
-    this.findPreference(SMSSecurePreferences.REPEAT_ALERTS_PREF)
+    this.findPreference(SilencePreferences.REPEAT_ALERTS_PREF)
         .setOnPreferenceChangeListener(new ListSummaryListener());
-    this.findPreference(SMSSecurePreferences.NOTIFICATION_PRIVACY_PREF)
+    this.findPreference(SilencePreferences.NOTIFICATION_PRIVACY_PREF)
         .setOnPreferenceChangeListener(new NotificationPrivacyListener());
 
-    initializeListSummary((ListPreference) findPreference(SMSSecurePreferences.LED_COLOR_PREF));
-    initializeListSummary((ListPreference) findPreference(SMSSecurePreferences.LED_BLINK_PREF));
-    initializeListSummary((ListPreference) findPreference(SMSSecurePreferences.REPEAT_ALERTS_PREF));
-    initializeListSummary((ListPreference) findPreference(SMSSecurePreferences.NOTIFICATION_PRIVACY_PREF));
-    initializeRingtoneSummary((RingtonePreference) findPreference(SMSSecurePreferences.RINGTONE_PREF));
+    initializeListSummary((ListPreference) findPreference(SilencePreferences.LED_COLOR_PREF));
+    initializeListSummary((ListPreference) findPreference(SilencePreferences.LED_BLINK_PREF));
+    initializeListSummary((ListPreference) findPreference(SilencePreferences.REPEAT_ALERTS_PREF));
+    initializeListSummary((ListPreference) findPreference(SilencePreferences.NOTIFICATION_PRIVACY_PREF));
+    initializeRingtoneSummary((RingtonePreference) findPreference(SilencePreferences.RINGTONE_PREF));
   }
 
   @Override
@@ -83,7 +83,7 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
     final int onCapsResId   = R.string.ApplicationPreferencesActivity_On;
     final int offCapsResId  = R.string.ApplicationPreferencesActivity_Off;
 
-    return context.getString(SMSSecurePreferences.isNotificationsEnabled(context) ? onCapsResId : offCapsResId);
+    return context.getString(SilencePreferences.isNotificationsEnabled(context) ? onCapsResId : offCapsResId);
   }
 
   private class NotificationPrivacyListener extends ListSummaryListener {

--- a/src/org/smssecure/smssecure/preferences/SmsMmsPreferenceFragment.java
+++ b/src/org/smssecure/smssecure/preferences/SmsMmsPreferenceFragment.java
@@ -19,7 +19,7 @@ import android.text.TextUtils;
 import org.smssecure.smssecure.ApplicationPreferencesActivity;
 import org.smssecure.smssecure.R;
 import org.smssecure.smssecure.components.OutgoingSmsPreference;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Util;
 
 import java.util.LinkedList;
@@ -49,8 +49,8 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
   private void initializePlatformSpecificOptions() {
     PreferenceScreen preferenceScreen    = getPreferenceScreen();
     Preference       defaultPreference   = findPreference(KITKAT_DEFAULT_PREF);
-    Preference       allSmsPreference    = findPreference(SMSSecurePreferences.ALL_SMS_PREF);
-    Preference       allMmsPreference    = findPreference(SMSSecurePreferences.ALL_MMS_PREF);
+    Preference       allSmsPreference    = findPreference(SilencePreferences.ALL_SMS_PREF);
+    Preference       allMmsPreference    = findPreference(SilencePreferences.ALL_MMS_PREF);
     Preference       manualMmsPreference = findPreference(MMS_PREF);
 
     if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
@@ -66,7 +66,7 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
         intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, getActivity().getPackageName());
         defaultPreference.setIntent(intent);
         defaultPreference.setTitle(getString(R.string.ApplicationPreferencesActivity_sms_disabled));
-        defaultPreference.setSummary(getString(R.string.ApplicationPreferencesActivity_touch_to_make_textsecure_your_default_sms_app));
+        defaultPreference.setSummary(getString(R.string.ApplicationPreferencesActivity_touch_to_make_silence_your_default_sms_app));
       }
     } else if (defaultPreference != null) {
       preferenceScreen.removePreference(defaultPreference);
@@ -105,8 +105,8 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
 
     final int incomingSmsSummary;
     boolean postKitkatSMS = Util.isDefaultSmsProvider(context);
-    boolean preKitkatSMS  = SMSSecurePreferences.isInterceptAllSmsEnabled(context);
-    boolean preKitkatMMS  = SMSSecurePreferences.isInterceptAllMmsEnabled(context);
+    boolean preKitkatSMS  = SilencePreferences.isInterceptAllSmsEnabled(context);
+    boolean preKitkatMMS  = SilencePreferences.isInterceptAllMmsEnabled(context);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
       if (postKitkatSMS)                      incomingSmsSummary = onResId;
       else                                    incomingSmsSummary = offResId;

--- a/src/org/smssecure/smssecure/service/KeyCachingService.java
+++ b/src/org/smssecure/smssecure/service/KeyCachingService.java
@@ -43,7 +43,7 @@ import org.smssecure.smssecure.crypto.MasterSecretUtil;
 import org.smssecure.smssecure.notifications.MessageNotifier;
 import org.smssecure.smssecure.util.DynamicLanguage;
 import org.smssecure.smssecure.util.ParcelUtil;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.whispersystems.jobqueue.EncryptionKeys;
 
 import java.util.concurrent.TimeUnit;
@@ -79,7 +79,7 @@ public class KeyCachingService extends Service {
   public KeyCachingService() {}
 
   public static synchronized MasterSecret getMasterSecret(Context context) {
-    if (masterSecret == null && SMSSecurePreferences.isPasswordDisabled(context)) {
+    if (masterSecret == null && SilencePreferences.isPasswordDisabled(context)) {
       try {
         MasterSecret masterSecret = MasterSecretUtil.getMasterSecret(context, MasterSecretUtil.UNENCRYPTED_PASSPHRASE);
         Intent       intent       = new Intent(context, KeyCachingService.class);
@@ -144,7 +144,7 @@ public class KeyCachingService extends Service {
     this.pending = PendingIntent.getService(this, 0, new Intent(PASSPHRASE_EXPIRED_EVENT, null,
                                                                 this, KeyCachingService.class), 0);
 
-    if (SMSSecurePreferences.isPasswordDisabled(this)) {
+    if (SilencePreferences.isPasswordDisabled(this)) {
       try {
         MasterSecret masterSecret = MasterSecretUtil.getMasterSecret(this, MasterSecretUtil.UNENCRYPTED_PASSPHRASE);
         setMasterSecret(masterSecret);
@@ -207,7 +207,7 @@ public class KeyCachingService extends Service {
   }
 
   private void handleDisableService() {
-    if (SMSSecurePreferences.isPasswordDisabled(this))
+    if (SilencePreferences.isPasswordDisabled(this))
       stopForeground(true);
   }
 
@@ -217,10 +217,10 @@ public class KeyCachingService extends Service {
   }
 
   private void startTimeoutIfAppropriate() {
-    boolean timeoutEnabled = SMSSecurePreferences.isPassphraseTimeoutEnabled(this);
+    boolean timeoutEnabled = SilencePreferences.isPassphraseTimeoutEnabled(this);
 
-    if ((activitiesRunning == 0) && (KeyCachingService.masterSecret != null) && timeoutEnabled && !SMSSecurePreferences.isPasswordDisabled(this)) {
-      long timeoutMinutes = SMSSecurePreferences.getPassphraseTimeoutInterval(this);
+    if ((activitiesRunning == 0) && (KeyCachingService.masterSecret != null) && timeoutEnabled && !SilencePreferences.isPasswordDisabled(this)) {
+      long timeoutMinutes = SilencePreferences.getPassphraseTimeoutInterval(this);
       long timeoutMillis  = TimeUnit.MINUTES.toMillis(timeoutMinutes);
 
       Log.w("KeyCachingService", "Starting timeout: " + timeoutMillis);
@@ -278,7 +278,7 @@ public class KeyCachingService extends Service {
   }
 
   private void foregroundService() {
-    if (SMSSecurePreferences.isPasswordDisabled(this)) {
+    if (SilencePreferences.isPasswordDisabled(this)) {
       stopForeground(true);
       return;
     }

--- a/src/org/smssecure/smssecure/service/MmsListener.java
+++ b/src/org/smssecure/smssecure/service/MmsListener.java
@@ -26,7 +26,7 @@ import android.util.Log;
 import org.smssecure.smssecure.ApplicationContext;
 import org.smssecure.smssecure.jobs.MmsReceiveJob;
 import org.smssecure.smssecure.protocol.WirePrefix;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Util;
 
 import ws.com.google.android.mms.pdu.GenericPdu;
@@ -55,7 +55,7 @@ public class MmsListener extends BroadcastReceiver {
     }
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT &&
-        SMSSecurePreferences.isInterceptAllMmsEnabled(context))
+        SilencePreferences.isInterceptAllMmsEnabled(context))
     {
       return true;
     }

--- a/src/org/smssecure/smssecure/service/QuickResponseService.java
+++ b/src/org/smssecure/smssecure/service/QuickResponseService.java
@@ -41,7 +41,7 @@ public class QuickResponseService extends MasterSecretIntentService {
 
     if (masterSecret == null) {
       Log.w(TAG, "Got quick response request when locked...");
-      Toast.makeText(this, R.string.QuickResponseService_quick_response_unavailable_when_SMSSecure_is_locked, Toast.LENGTH_LONG).show();
+      Toast.makeText(this, R.string.QuickResponseService_quick_response_unavailable_when_Silence_is_locked, Toast.LENGTH_LONG).show();
       return;
     }
 

--- a/src/org/smssecure/smssecure/service/SmsListener.java
+++ b/src/org/smssecure/smssecure/service/SmsListener.java
@@ -29,7 +29,7 @@ import org.smssecure.smssecure.ApplicationContext;
 import org.smssecure.smssecure.jobs.SmsReceiveJob;
 import org.smssecure.smssecure.protocol.WirePrefix;
 import org.smssecure.smssecure.sms.IncomingTextMessage;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Util;
 
 import java.util.ArrayList;
@@ -101,7 +101,7 @@ public class SmsListener extends BroadcastReceiver {
     }
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT &&
-        SMSSecurePreferences.isInterceptAllSmsEnabled(context))
+        SilencePreferences.isInterceptAllSmsEnabled(context))
     {
       return true;
     }

--- a/src/org/smssecure/smssecure/sms/MessageSender.java
+++ b/src/org/smssecure/smssecure/sms/MessageSender.java
@@ -35,7 +35,7 @@ import org.smssecure.smssecure.recipients.Recipient;
 import org.smssecure.smssecure.recipients.Recipients;
 import org.smssecure.smssecure.util.GroupUtil;
 import org.smssecure.smssecure.util.InvalidNumberException;
-import org.smssecure.smssecure.util.SMSSecurePreferences;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.Util;
 import org.whispersystems.jobqueue.JobManager;
 import org.whispersystems.libaxolotl.util.guava.Optional;

--- a/src/org/smssecure/smssecure/util/DynamicIntroTheme.java
+++ b/src/org/smssecure/smssecure/util/DynamicIntroTheme.java
@@ -7,10 +7,10 @@ import org.smssecure.smssecure.R;
 public class DynamicIntroTheme extends DynamicTheme {
   @Override
   protected int getSelectedTheme(Activity activity) {
-    String theme = SMSSecurePreferences.getTheme(activity);
+    String theme = SilencePreferences.getTheme(activity);
 
-    if (theme.equals("dark")) return R.style.SMSSecure_DarkIntroTheme;
+    if (theme.equals("dark")) return R.style.Silence_DarkIntroTheme;
 
-    return R.style.SMSSecure_LightIntroTheme;
+    return R.style.Silence_LightIntroTheme;
   }
 }

--- a/src/org/smssecure/smssecure/util/DynamicLanguage.java
+++ b/src/org/smssecure/smssecure/util/DynamicLanguage.java
@@ -66,7 +66,7 @@ public class DynamicLanguage {
   }
 
   private static Locale getSelectedLocale(Context context) {
-    String language[] = TextUtils.split(SMSSecurePreferences.getLanguage(context), "-r");
+    String language[] = TextUtils.split(SilencePreferences.getLanguage(context), "-r");
 
     if (language[0].equals(DEFAULT)) {
       return Locale.getDefault();

--- a/src/org/smssecure/smssecure/util/DynamicNoActionBarTheme.java
+++ b/src/org/smssecure/smssecure/util/DynamicNoActionBarTheme.java
@@ -7,10 +7,10 @@ import org.smssecure.smssecure.R;
 public class DynamicNoActionBarTheme extends DynamicTheme {
   @Override
   protected int getSelectedTheme(Activity activity) {
-    String theme = SMSSecurePreferences.getTheme(activity);
+    String theme = SilencePreferences.getTheme(activity);
 
-    if (theme.equals("dark")) return R.style.SMSSecure_DarkNoActionBar;
+    if (theme.equals("dark")) return R.style.Silence_DarkNoActionBar;
 
-    return R.style.SMSSecure_LightNoActionBar;
+    return R.style.Silence_LightNoActionBar;
   }
 }

--- a/src/org/smssecure/smssecure/util/DynamicTheme.java
+++ b/src/org/smssecure/smssecure/util/DynamicTheme.java
@@ -25,11 +25,11 @@ public class DynamicTheme {
   }
 
   protected int getSelectedTheme(Activity activity) {
-    String theme = SMSSecurePreferences.getTheme(activity);
+    String theme = SilencePreferences.getTheme(activity);
 
-    if (theme.equals("dark")) return R.style.SMSSecure_DarkTheme;
+    if (theme.equals("dark")) return R.style.Silence_DarkTheme;
 
-    return R.style.SMSSecure_LightTheme;
+    return R.style.Silence_LightTheme;
   }
 
   private static final class OverridePendingTransition {

--- a/src/org/smssecure/smssecure/util/SilencePreferences.java
+++ b/src/org/smssecure/smssecure/util/SilencePreferences.java
@@ -17,9 +17,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-public class SMSSecurePreferences {
+public class SilencePreferences {
 
-  private static final String TAG = SMSSecurePreferences.class.getSimpleName();
+  private static final String TAG = SilencePreferences.class.getSimpleName();
 
   public  static final String CHANGE_PASSPHRASE_PREF           = "pref_change_passphrase";
   public  static final String DISABLE_PASSPHRASE_PREF          = "pref_disable_passphrase";
@@ -41,6 +41,7 @@ public class SMSSecurePreferences {
 
   private static final String LAST_VERSION_CODE_PREF           = "last_version_code";
   private static final String IS_FIRST_RUN                     = "is_first_run";
+  private static final String SEEN_BRAND_NAME_UPDATE           = "seen_brand_name_update";
   public  static final String RINGTONE_PREF                    = "pref_key_ringtone";
   private static final String VIBRATE_PREF                     = "pref_key_vibrate";
   private static final String NOTIFICATION_PREF                = "pref_key_enable_notifications";
@@ -257,7 +258,7 @@ public class SMSSecurePreferences {
   }
 
   public static boolean getUseCustomMmsc(Context context) {
-    boolean legacy = SMSSecurePreferences.isLegacyUseLocalApnsEnabled(context);
+    boolean legacy = SilencePreferences.isLegacyUseLocalApnsEnabled(context);
     return getBooleanPreference(context, MMSC_CUSTOM_HOST_PREF, legacy);
   }
 
@@ -274,7 +275,7 @@ public class SMSSecurePreferences {
   }
 
   public static boolean getUseCustomMmscProxy(Context context) {
-    boolean legacy = SMSSecurePreferences.isLegacyUseLocalApnsEnabled(context);
+    boolean legacy = SilencePreferences.isLegacyUseLocalApnsEnabled(context);
     return getBooleanPreference(context, MMSC_CUSTOM_PROXY_PREF, legacy);
   }
 
@@ -291,7 +292,7 @@ public class SMSSecurePreferences {
   }
 
   public static boolean getUseCustomMmscProxyPort(Context context) {
-    boolean legacy = SMSSecurePreferences.isLegacyUseLocalApnsEnabled(context);
+    boolean legacy = SilencePreferences.isLegacyUseLocalApnsEnabled(context);
     return getBooleanPreference(context, MMSC_CUSTOM_PROXY_PORT_PREF, legacy);
   }
 
@@ -308,7 +309,7 @@ public class SMSSecurePreferences {
   }
 
   public static boolean getUseCustomMmscUsername(Context context) {
-    boolean legacy = SMSSecurePreferences.isLegacyUseLocalApnsEnabled(context);
+    boolean legacy = SilencePreferences.isLegacyUseLocalApnsEnabled(context);
     return getBooleanPreference(context, MMSC_CUSTOM_USERNAME_PREF, legacy);
   }
 
@@ -325,7 +326,7 @@ public class SMSSecurePreferences {
   }
 
   public static boolean getUseCustomMmscPassword(Context context) {
-    boolean legacy = SMSSecurePreferences.isLegacyUseLocalApnsEnabled(context);
+    boolean legacy = SilencePreferences.isLegacyUseLocalApnsEnabled(context);
     return getBooleanPreference(context, MMSC_CUSTOM_PASSWORD_PREF, legacy);
   }
 
@@ -378,6 +379,14 @@ public class SMSSecurePreferences {
     setBooleanPreference(context, IS_FIRST_RUN, false);
   }
 
+  public static boolean seenBrandNameUpdate(Context context) {
+    return getBooleanPreference(context, SEEN_BRAND_NAME_UPDATE, false);
+  }
+
+  public static void setBrandNameUpdateAsSeen(Context context) {
+    setBooleanPreference(context, SEEN_BRAND_NAME_UPDATE, true);
+  }
+
   public static String getTheme(Context context) {
     return getStringPreference(context, THEME_PREF, "light");
   }
@@ -395,7 +404,7 @@ public class SMSSecurePreferences {
   }
 
   public static void setPushRegistered(Context context, boolean registered) {
-    Log.w("SMSSecurePreferences", "Setting push registered: " + registered);
+    Log.w("SilencePreferences", "Setting push registered: " + registered);
     setBooleanPreference(context, REGISTERED_GCM_PREF, registered);
   }
 

--- a/src/org/smssecure/smssecure/util/Util.java
+++ b/src/org/smssecure/smssecure/util/Util.java
@@ -160,7 +160,7 @@ public class Util {
   public static String canonicalizeNumber(Context context, String number)
       throws InvalidNumberException
   {
-    String localNumber = SMSSecurePreferences.getLocalNumber(context);
+    String localNumber = SilencePreferences.getLocalNumber(context);
     return PhoneNumberFormatter.formatNumber(number, localNumber);
   }
 

--- a/src/org/smssecure/smssecure/util/VersionTracker.java
+++ b/src/org/smssecure/smssecure/util/VersionTracker.java
@@ -9,13 +9,13 @@ public class VersionTracker {
 
 
   public static int getLastSeenVersion(Context context) {
-    return SMSSecurePreferences.getLastVersionCode(context);
+    return SilencePreferences.getLastVersionCode(context);
   }
 
   public static void updateLastSeenVersion(Context context) {
     try {
       int currentVersionCode = Util.getCurrentApkReleaseVersion(context);
-      SMSSecurePreferences.setLastVersionCode(context, currentVersionCode);
+      SilencePreferences.setLastVersionCode(context, currentVersionCode);
     } catch (IOException ioe) {
       throw new AssertionError(ioe);
     }

--- a/test/androidTest/java/org/smssecure/smssecure/SilenceTestCase.java
+++ b/test/androidTest/java/org/smssecure/smssecure/SilenceTestCase.java
@@ -3,7 +3,7 @@ package org.smssecure.smssecure;
 import android.content.Context;
 import android.test.InstrumentationTestCase;
 
-public class SMSSecureTestCase extends InstrumentationTestCase {
+public class SilenceTestCase extends InstrumentationTestCase {
 
   @Override
   public void setUp() throws Exception {

--- a/test/androidTest/java/org/smssecure/smssecure/database/CanonicalAddressDatabaseTest.java
+++ b/test/androidTest/java/org/smssecure/smssecure/database/CanonicalAddressDatabaseTest.java
@@ -1,10 +1,10 @@
 package org.smssecure.smssecure.database;
 
-import org.smssecure.smssecure.SMSSecureTestCase;
+import org.smssecure.smssecure.SilenceTestCase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CanonicalAddressDatabaseTest extends SMSSecureTestCase {
+public class CanonicalAddressDatabaseTest extends SilenceTestCase {
   private static final String AMBIGUOUS_NUMBER = "222-3333";
   private static final String SPECIFIC_NUMBER  = "+49 444 222 3333";
   private static final String EMAIL            = "a@b.fom";


### PR DESCRIPTION
CellTrust is [currently trying to ban SMSSecure](https://twitter.com/SMSSecure_/status/714891540360007681) from app stores. The company claims that SMSSecure creates a confusion with their trademark SecureSMS.

We don't want to fight against fools and we will change the name of the app. This PR shows a notification to the user to focus on the new name.

Suggestions for the new name are opened and you can comment on this PR to make proposals. We have to find it very quickly as SMSSecure is not available on the Amazon App Store and on the US Play Store anymore.

The new name must not be a registered trademark ([a directory of trademarks is available online](https://www.tmdn.org/tmview/welcome)) and its domain name should be available (at least .org and/or .im and/or .io).