### PR TITLE
Display download button when manual mms prefeference is set up

### DIFF
--- a/src/org/smssecure/smssecure/ConversationItem.java
+++ b/src/org/smssecure/smssecure/ConversationItem.java
@@ -407,7 +407,7 @@ public class ConversationItem extends LinearLayout
 
     dateText.setText(messageSize + "\n" + expires);
 
-    if (MmsDatabase.Status.isDisplayDownloadButton(messageRecord.getStatus())) {
+    if (MmsDatabase.Status.isDisplayDownloadButton(context, messageRecord.getStatus())) {
       mmsDownloadButton.setVisibility(View.VISIBLE);
       mmsDownloadingLabel.setVisibility(View.GONE);
     } else {

--- a/src/org/smssecure/smssecure/database/MmsDatabase.java
+++ b/src/org/smssecure/smssecure/database/MmsDatabase.java
@@ -851,11 +851,12 @@ public class MmsDatabase extends MessagingDatabase {
     public static final int DOWNLOAD_HARD_FAILURE    = 5;
     public static final int DOWNLOAD_APN_UNAVAILABLE = 6;
 
-    public static boolean isDisplayDownloadButton(int status) {
+    public static boolean isDisplayDownloadButton(Context context, int status) {
       return
           status == DOWNLOAD_INITIALIZED     ||
           status == DOWNLOAD_NO_CONNECTIVITY ||
-          status == DOWNLOAD_SOFT_FAILURE;
+          status == DOWNLOAD_SOFT_FAILURE    ||
+         (status == DOWNLOAD_APN_UNAVAILABLE && SilencePreferences.seenManualMmsSettings(context));
     }
 
     public static String getLabelForStatus(Context context, int status) {

--- a/src/org/smssecure/smssecure/preferences/MmsPreferencesFragment.java
+++ b/src/org/smssecure/smssecure/preferences/MmsPreferencesFragment.java
@@ -44,6 +44,8 @@ public class MmsPreferencesFragment extends PreferenceFragment {
 
     ((PassphraseRequiredActionBarActivity) getActivity()).getSupportActionBar()
         .setTitle(R.string.preferences__advanced_mms_access_point_names);
+
+    SilencePreferences.setManualMmsSettingsAsSeen(getActivity());
   }
 
   @Override

--- a/src/org/smssecure/smssecure/util/SilencePreferences.java
+++ b/src/org/smssecure/smssecure/util/SilencePreferences.java
@@ -38,6 +38,7 @@ public class SilencePreferences {
   public  static final String THREAD_TRIM_LENGTH               = "pref_trim_length";
   public  static final String THREAD_TRIM_NOW                  = "pref_trim_now";
   public  static final String ENABLE_MANUAL_MMS_PREF           = "pref_enable_manual_mms";
+  private static final String SEEN_MANUAL_MMS_SETTINGS_PREF    = "seen_manual_mms_settings";
 
   private static final String LAST_VERSION_CODE_PREF           = "last_version_code";
   private static final String IS_FIRST_RUN                     = "is_first_run";
@@ -359,6 +360,14 @@ public class SilencePreferences {
 
   public static boolean isLegacyUseLocalApnsEnabled(Context context) {
     return getBooleanPreference(context, ENABLE_MANUAL_MMS_PREF, false);
+  }
+
+  public static boolean seenManualMmsSettings(Context context) {
+    return getBooleanPreference(context, SEEN_MANUAL_MMS_SETTINGS_PREF, false);
+  }
+
+  public static void setManualMmsSettingsAsSeen(Context context) {
+    setBooleanPreference(context, SEEN_MANUAL_MMS_SETTINGS_PREF, true);
   }
 
   public static int getLastVersionCode(Context context) {


### PR DESCRIPTION
If manual APN settings are required, incoming MMS message displays a text to invite the user to set up those settings. But when it's done, messages cannot be downloaded because of this text. This PR display the Download button if the form to set up APN settings has been seen.

Fixes #400.