### PR TITLE
Add XMPP message type

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="ConversationItem_unable_to_open_media">Can\'t find an app able to open this media.</string>
     <string name="ConversationItem_from_s">from %s</string>
     <string name="ConversationItem_to_s">to %s</string>
+    <string name="ConversationItem_xmpp_address">XMPP address. Update Silence to enable this feature.</string>
 
     <!-- ConversationActivity -->
     <string name="ConversationActivity_initiate_secure_session_question">Initiate secure session?</string>

--- a/src/org/smssecure/smssecure/database/MmsSmsColumns.java
+++ b/src/org/smssecure/smssecure/database/MmsSmsColumns.java
@@ -59,6 +59,9 @@ public interface MmsSmsColumns {
     protected static final long GROUP_UPDATE_BIT = 0x10000;
     protected static final long GROUP_QUIT_BIT   = 0x20000;
 
+    // XMPP Message Information
+    protected static final long XMPP_EXCHANGE_BIT = 0x3000000;
+
     // Encrypted Storage Information
     protected static final long ENCRYPTION_MASK                  = 0xFF000000;
     protected static final long ENCRYPTION_SYMMETRIC_BIT         = 0x80000000;
@@ -189,6 +192,10 @@ public interface MmsSmsColumns {
 
     public static boolean isLegacyType(long type) {
       return (type & ENCRYPTION_REMOTE_LEGACY_BIT) != 0;
+    }
+
+    public static boolean isXmppExchangeType(long type) {
+      return (type & XMPP_EXCHANGE_BIT) != 0;
     }
 
     public static long translateFromSystemBaseType(long theirType) {

--- a/src/org/smssecure/smssecure/database/SmsDatabase.java
+++ b/src/org/smssecure/smssecure/database/SmsDatabase.java
@@ -215,6 +215,10 @@ public class SmsDatabase extends MessagingDatabase {
     updateTypeBitmask(id, Types.PUSH_MESSAGE_BIT, Types.MESSAGE_FORCE_SMS_BIT);
   }
 
+  public void markAsXmppExchange(long id) {
+    updateTypeBitmask(id, 0, Types.XMPP_EXCHANGE_BIT);
+  }
+
   public void markAsDecryptFailed(long id) {
     updateTypeBitmask(id, Types.ENCRYPTION_MASK, Types.ENCRYPTION_REMOTE_FAILED_BIT);
   }
@@ -354,6 +358,8 @@ public class SmsDatabase extends MessagingDatabase {
       else if (((IncomingKeyExchangeMessage)message).isLegacyVersion())  type |= Types.ENCRYPTION_REMOTE_LEGACY_BIT;
       else if (((IncomingKeyExchangeMessage)message).isDuplicate())      type |= Types.ENCRYPTION_REMOTE_DUPLICATE_BIT;
       else if (((IncomingKeyExchangeMessage)message).isPreKeyBundle())   type |= Types.KEY_EXCHANGE_BUNDLE_BIT;
+    } else if (message.isXmppExchange()) {
+      type |= Types.XMPP_EXCHANGE_BIT;
     } else if (message.isSecureMessage()) {
       type |= Types.SECURE_MESSAGE_BIT;
 //      type |= Types.ENCRYPTION_REMOTE_BIT;

--- a/src/org/smssecure/smssecure/database/model/DisplayRecord.java
+++ b/src/org/smssecure/smssecure/database/model/DisplayRecord.java
@@ -104,6 +104,10 @@ public abstract class DisplayRecord {
     return SmsDatabase.Types.isKeyExchangeType(type);
   }
 
+  public boolean isXmppExchange() {
+    return SmsDatabase.Types.isXmppExchangeType(type);
+  }
+
   public boolean isEndSession() {
     return SmsDatabase.Types.isEndSessionType(type);
   }

--- a/src/org/smssecure/smssecure/database/model/MessageRecord.java
+++ b/src/org/smssecure/smssecure/database/model/MessageRecord.java
@@ -156,6 +156,10 @@ public abstract class MessageRecord extends DisplayRecord {
     return SmsDatabase.Types.isInvalidVersionKeyExchange(type);
   }
 
+  public boolean isXmppExchange() {
+    return SmsDatabase.Types.isXmppExchangeType(type);
+  }
+
   public Recipient getIndividualRecipient() {
     return individualRecipient;
   }

--- a/src/org/smssecure/smssecure/database/model/SmsMessageRecord.java
+++ b/src/org/smssecure/smssecure/database/model/SmsMessageRecord.java
@@ -71,6 +71,8 @@ public class SmsMessageRecord extends MessageRecord {
       return emphasisAdded(context.getString(R.string.SmsMessageRecord_received_corrupted_key_exchange_message));
     } else if (isInvalidVersionKeyExchange()) {
       return emphasisAdded(context.getString(R.string.SmsMessageRecord_received_key_exchange_message_for_invalid_protocol_version));
+    } else if (isXmppExchange()) {
+      return emphasisAdded(context.getString(R.string.ConversationItem_xmpp_address));
     } else if (MmsSmsColumns.Types.isLegacyType(type)) {
       return emphasisAdded(context.getString(R.string.MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported));
     } else if (isBundleKeyExchange()) {

--- a/src/org/smssecure/smssecure/database/model/ThreadRecord.java
+++ b/src/org/smssecure/smssecure/database/model/ThreadRecord.java
@@ -74,6 +74,8 @@ public class ThreadRecord extends DisplayRecord {
       return emphasisAdded(context.getString(R.string.ThreadRecord_left_the_group));
     } else if (isKeyExchange()) {
       return emphasisAdded(context.getString(R.string.ConversationListItem_key_exchange_message));
+    } else if (isXmppExchange()) {
+      return emphasisAdded(context.getString(R.string.ConversationItem_xmpp_address));
     } else if (SmsDatabase.Types.isFailedDecryptType(type)) {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_bad_encrypted_message));
     } else if (SmsDatabase.Types.isNoRemoteSessionType(type)) {

--- a/src/org/smssecure/smssecure/jobs/SmsReceiveJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsReceiveJob.java
@@ -92,7 +92,7 @@ public class SmsReceiveJob extends ContextJob {
       messageAndThreadId = database.insertMessageInbox(masterSecret, message);
     }
 
-    if (masterSecret == null || message.isSecureMessage() || message.isKeyExchange() || message.isEndSession()) {
+    if (masterSecret == null || message.isSecureMessage() || message.isKeyExchange() || message.isEndSession() || message.isXmppExchange()) {
       ApplicationContext.getInstance(context)
                         .getJobManager()
                         .add(new SmsDecryptJob(context, messageAndThreadId.first));

--- a/src/org/smssecure/smssecure/protocol/WirePrefix.java
+++ b/src/org/smssecure/smssecure/protocol/WirePrefix.java
@@ -56,11 +56,16 @@ public abstract class WirePrefix {
     return verifyPrefix("?TSE", message);
   }
 
+  public static boolean isXmppExchange(String message) {
+    return verifyPrefix("?TSX", message);
+  }
+
   public static boolean isPrefixedMessage(String message) {
     return isEncryptedMessage(message) ||
            isKeyExchange(message)      ||
            isPreKeyBundle(message)     ||
-           isEndSession(message);
+           isEndSession(message)       ||
+           isXmppExchange(message);
   }
 
   public static String calculateKeyExchangePrefix(String message) {
@@ -77,6 +82,10 @@ public abstract class WirePrefix {
 
   public static String calculateEndSessionPrefix(String message) {
     return calculatePrefix(("?TSE" + message).getBytes(), PREFIX_BYTES);
+  }
+
+  public static String calculateXmppExchangePrefix(String message) {
+    return calculatePrefix(("?TSX" + message).getBytes(), PREFIX_BYTES);
   }
 
   private static boolean verifyPrefix(String prefixType, String message) {

--- a/src/org/smssecure/smssecure/protocol/XmppExchangeWirePrefix.java
+++ b/src/org/smssecure/smssecure/protocol/XmppExchangeWirePrefix.java
@@ -1,0 +1,8 @@
+package org.smssecure.smssecure.protocol;
+
+public class XmppExchangeWirePrefix extends WirePrefix {
+  @Override
+  public String calculatePrefix(String message) {
+    return super.calculateXmppExchangePrefix(message);
+  }
+}

--- a/src/org/smssecure/smssecure/sms/IncomingTextMessage.java
+++ b/src/org/smssecure/smssecure/sms/IncomingTextMessage.java
@@ -170,6 +170,10 @@ public class IncomingTextMessage implements Parcelable {
     return false;
   }
 
+  public boolean isXmppExchange() {
+    return false;
+  }
+
   public boolean isSecureMessage() {
     return false;
   }

--- a/src/org/smssecure/smssecure/sms/IncomingXmppExchangeMessage.java
+++ b/src/org/smssecure/smssecure/sms/IncomingXmppExchangeMessage.java
@@ -1,0 +1,28 @@
+package org.smssecure.smssecure.sms;
+
+public class IncomingXmppExchangeMessage extends IncomingTextMessage {
+
+  private boolean isDuplicate;
+
+  public IncomingXmppExchangeMessage(IncomingTextMessage base, String newBody) {
+    super(base, newBody);
+  }
+
+  @Override
+  public IncomingTextMessage withMessageBody(String messageBody) {
+    return new IncomingXmppExchangeMessage(this, messageBody);
+  }
+
+  public void setDuplicate(boolean isDuplicate) {
+    this.isDuplicate = isDuplicate;
+  }
+
+  public boolean isDuplicate() {
+    return isDuplicate;
+  }
+
+  @Override
+  public boolean isXmppExchange() {
+    return true;
+  }
+}

--- a/src/org/smssecure/smssecure/sms/MultipartSmsMessageHandler.java
+++ b/src/org/smssecure/smssecure/sms/MultipartSmsMessageHandler.java
@@ -74,6 +74,8 @@ public class MultipartSmsMessageHandler {
       return new IncomingPreKeyBundleMessage(message.getBaseMessage(), strippedMessage);
     } else if (message.getWireType() == MultipartSmsTransportMessage.WIRETYPE_END_SESSION) {
       return new IncomingEndSessionMessage(message.getBaseMessage(), strippedMessage);
+    } else if (message.getWireType() == MultipartSmsTransportMessage.WIRETYPE_XMPP_EXCHANGE) {
+      return new IncomingXmppExchangeMessage(message.getBaseMessage(), strippedMessage);
     } else {
       return new IncomingEncryptedMessage(message.getBaseMessage(), strippedMessage);
     }

--- a/src/org/smssecure/smssecure/sms/MultipartSmsTransportMessage.java
+++ b/src/org/smssecure/smssecure/sms/MultipartSmsTransportMessage.java
@@ -6,6 +6,7 @@ import org.smssecure.smssecure.protocol.EndSessionWirePrefix;
 import org.smssecure.smssecure.protocol.KeyExchangeWirePrefix;
 import org.smssecure.smssecure.protocol.PrekeyBundleWirePrefix;
 import org.smssecure.smssecure.protocol.SecureMessageWirePrefix;
+import org.smssecure.smssecure.protocol.XmppExchangeWirePrefix;
 import org.smssecure.smssecure.protocol.WirePrefix;
 import org.smssecure.smssecure.util.Base64;
 import org.smssecure.smssecure.util.Conversions;
@@ -22,10 +23,11 @@ public class MultipartSmsTransportMessage {
   public static final int MULTI_MESSAGE_MULTIPART_OVERHEAD       = 3;
   public static final int FIRST_MULTI_MESSAGE_MULTIPART_OVERHEAD = 2;
 
-  public static final int WIRETYPE_SECURE      = 1;
-  public static final int WIRETYPE_KEY         = 2;
-  public static final int WIRETYPE_PREKEY      = 3;
-  public static final int WIRETYPE_END_SESSION = 4;
+  public static final int WIRETYPE_SECURE        = 1;
+  public static final int WIRETYPE_KEY           = 2;
+  public static final int WIRETYPE_PREKEY        = 3;
+  public static final int WIRETYPE_END_SESSION   = 4;
+  public static final int WIRETYPE_XMPP_EXCHANGE = 5;
 
   private static final int VERSION_OFFSET    = 0;
   private static final int MULTIPART_OFFSET  = 1;
@@ -42,6 +44,7 @@ public class MultipartSmsTransportMessage {
     if      (WirePrefix.isEncryptedMessage(message.getMessageBody())) wireType = WIRETYPE_SECURE;
     else if (WirePrefix.isPreKeyBundle(message.getMessageBody()))     wireType = WIRETYPE_PREKEY;
     else if (WirePrefix.isEndSession(message.getMessageBody()))       wireType = WIRETYPE_END_SESSION;
+    else if (WirePrefix.isXmppExchange(message.getMessageBody()))     wireType = WIRETYPE_XMPP_EXCHANGE;
     else                                                              wireType = WIRETYPE_KEY;
 
     Log.w(TAG, "Decoded message with version: " + getCurrentVersion());


### PR DESCRIPTION
#390 will introduce a new type of message used to share XMPP addresses using SMS messages. This new type of message will result in gibberish if users don't have an updated version of Silence. So when #390 will be merged, the risk is to create some confusion with users that still use a version of Silence without XMPP support.

This PR adds this new type of message but do not add XMPP support as it is still in development. If we release a new Silence version very soon with this message type, users won't have a gibberish when #390 will be merged (in about 1 month).