### PR TITLE
Revert "request delivery reports by default"

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -828,6 +828,9 @@
     <string name="reminder_header_rate_title">Rate this app</string>
     <string name="reminder_header_rate_text">If you enjoy using this app, please take a moment to help us by rating it.</string>
     <string name="reminder_header_rate_button">RATE NOW!</string>
+    <string name="reminder_header_delivery_reports_title">Enable delivery reports?</string>
+    <string name="reminder_header_delivery_reports_text">Delivery reports allow you to know if and when your recipient had received your messages. Some mobile networks charge additional fee.</string>
+    <string name="reminder_header_delivery_reports_button">ENABLE</string>
     <string name="reminder_header_close_button">CLOSE</string>
 
     <!-- MediaPreviewActivity -->

--- a/res/xml/preferences_sms_mms.xml
+++ b/res/xml/preferences_sms_mms.xml
@@ -24,7 +24,7 @@
                         android:defaultValue="false" />
 
     <org.smssecure.smssecure.components.SwitchPreferenceCompat
-                        android:defaultValue="true"
+                        android:defaultValue="false"
                         android:key="pref_delivery_report_sms"
                         android:summary="@string/preferences__request_a_delivery_report_for_each_sms_message_you_send"
                         android:title="@string/preferences__sms_delivery_reports" />

--- a/src/org/smssecure/smssecure/ConversationListFragment.java
+++ b/src/org/smssecure/smssecure/ConversationListFragment.java
@@ -54,6 +54,7 @@ import android.view.Window;
 
 import org.smssecure.smssecure.ConversationListAdapter.ItemClickListener;
 import org.smssecure.smssecure.components.reminder.DefaultSmsReminder;
+import org.smssecure.smssecure.components.reminder.DeliveryReportsReminder;
 import org.smssecure.smssecure.components.reminder.Reminder;
 import org.smssecure.smssecure.components.reminder.ReminderView;
 import org.smssecure.smssecure.components.reminder.StoreRatingReminder;
@@ -160,6 +161,8 @@ public class ConversationListFragment extends Fragment
           return Optional.of(new DefaultSmsReminder(context));
         } else if (Util.isDefaultSmsProvider(context) && SystemSmsImportReminder.isEligible(context)) {
           return Optional.of((new SystemSmsImportReminder(context, masterSecret)));
+        } else if (DeliveryReportsReminder.isEligible(context)) {
+          return Optional.of((new DeliveryReportsReminder(context)));
         } else if (StoreRatingReminder.isEligible(context)) {
           return Optional.of((new StoreRatingReminder(context)));
         } else {

--- a/src/org/smssecure/smssecure/components/reminder/DeliveryReportsReminder.java
+++ b/src/org/smssecure/smssecure/components/reminder/DeliveryReportsReminder.java
@@ -1,0 +1,37 @@
+package org.smssecure.smssecure.components.reminder;
+
+import android.content.Context;
+import android.view.View;
+import android.view.View.OnClickListener;
+
+import org.smssecure.smssecure.R;
+import org.smssecure.smssecure.util.SilencePreferences;
+
+public class DeliveryReportsReminder extends Reminder {
+
+  public DeliveryReportsReminder(final Context context) {
+    super(context.getString(R.string.reminder_header_delivery_reports_title),
+          context.getString(R.string.reminder_header_delivery_reports_text),
+          context.getString(R.string.reminder_header_delivery_reports_button));
+
+    final OnClickListener okListener = new OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        SilencePreferences.setSmsDeliveryReportsEnabled(context);
+        SilencePreferences.setPromptedDeliveryReportsReminder(context);
+      }
+    };
+    final OnClickListener dismissListener = new OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        SilencePreferences.setPromptedDeliveryReportsReminder(context);
+      }
+    };
+    setOkListener(okListener);
+    setDismissListener(dismissListener);
+  }
+
+  public static boolean isEligible(Context context) {
+    return !SilencePreferences.isSmsDeliveryReportsEnabled(context) && !SilencePreferences.hasPromptedDeliveryReportsReminder(context);
+  }
+}

--- a/src/org/smssecure/smssecure/components/reminder/ReminderView.java
+++ b/src/org/smssecure/smssecure/components/reminder/ReminderView.java
@@ -53,7 +53,13 @@ public class ReminderView extends LinearLayout {
     text.setText(reminder.getText());
     acceptButton.setText(reminder.getButtonText());
 
-    acceptButton.setOnClickListener(reminder.getOkListener());
+    acceptButton.setOnClickListener(new OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        hide();
+        if (reminder.getOkListener() != null) reminder.getOkListener().onClick(v);
+      }
+    });
 
     if (reminder.isDismissable()) {
       closeButton.setOnClickListener(new OnClickListener() {

--- a/src/org/smssecure/smssecure/util/SilencePreferences.java
+++ b/src/org/smssecure/smssecure/util/SilencePreferences.java
@@ -56,6 +56,7 @@ public class SilencePreferences {
   private static final String AUTO_KEY_EXCHANGE_PREF           = "pref_auto_complete_key_exchange";
   public  static final String SCREEN_SECURITY_PREF             = "pref_screen_security";
   public  static final String ENTER_KEY_TYPE                   = "pref_enter_key_type";
+  private static final String PROMPTED_DELIVERY_REPORTS_PREF   = "pref_prompted_delivery_reports";
   private static final String SMS_DELIVERY_REPORT_PREF         = "pref_delivery_report_sms";
   private static final String SMS_DELIVERY_REPORT_TOAST_PREF   = "pref_delivery_report_toast_sms";
   public  static final String MMS_USER_AGENT                   = "pref_mms_user_agent";
@@ -435,6 +436,18 @@ public class SilencePreferences {
 
   public static void setLanguage(Context context, String language) {
     setStringPreference(context, LANGUAGE_PREF, language);
+  }
+
+  public static boolean hasPromptedDeliveryReportsReminder(Context context) {
+    return getBooleanPreference(context, PROMPTED_DELIVERY_REPORTS_PREF, false);
+  }
+
+  public static void setPromptedDeliveryReportsReminder(Context context) {
+    setBooleanPreference(context, PROMPTED_DELIVERY_REPORTS_PREF, true);
+  }
+
+  public static void setSmsDeliveryReportsEnabled(Context context) {
+    setBooleanPreference(context, SMS_DELIVERY_REPORT_PREF, true);
   }
 
   public static boolean isSmsDeliveryReportsEnabled(Context context) {

--- a/src/org/smssecure/smssecure/util/SilencePreferences.java
+++ b/src/org/smssecure/smssecure/util/SilencePreferences.java
@@ -438,7 +438,7 @@ public class SilencePreferences {
   }
 
   public static boolean isSmsDeliveryReportsEnabled(Context context) {
-    return getBooleanPreference(context, SMS_DELIVERY_REPORT_PREF, true);
+    return getBooleanPreference(context, SMS_DELIVERY_REPORT_PREF, false);
   }
 
   public static boolean isSmsDeliveryReportsToastEnabled(Context context) {


### PR DESCRIPTION
This reverts commit b0e1020fd2da32352edbb22709fe0edaa0f2eee8.

Some mobile networks charge for delivery reports so this option
shouldn't be on by default.
