### PR TITLE
Fix notification vibration in Android N

### DIFF
--- a/src/org/smssecure/smssecure/jobs/SmsDecryptJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsDecryptJob.java
@@ -80,7 +80,7 @@ public class SmsDecryptJob extends MasterSecretJob {
       else if (message.isXmppExchange())  handleXmppExchangeMessage(masterSecret, messageId, threadId, (IncomingXmppExchangeMessage) message);
       else                                database.updateMessageBody(masterSecret, messageId, message.getMessageBody());
 
-      MessageNotifier.updateNotification(context, masterSecret);
+      MessageNotifier.updateNotification(context, masterSecret, MessageNotifier.MNF_LIGHTS_KEEP, threadId, true);
     } catch (LegacyMessageException e) {
       Log.w(TAG, e);
       database.markAsLegacyVersion(messageId);

--- a/src/org/smssecure/smssecure/jobs/SmsReceiveJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsReceiveJob.java
@@ -53,7 +53,14 @@ public class SmsReceiveJob extends ContextJob {
 
     if (message.isPresent() && !isBlocked(message.get())) {
       Pair<Long, Long> messageAndThreadId = storeMessage(message.get());
-      MessageNotifier.updateNotification(context, KeyCachingService.getMasterSecret(context), messageAndThreadId.second);
+
+      IncomingTextMessage incomingTextMessage = message.get();
+      if (!incomingTextMessage.isSecureMessage() &&
+          !incomingTextMessage.isKeyExchange()   &&
+          !incomingTextMessage.isXmppExchange())
+      {
+        MessageNotifier.updateNotification(context, KeyCachingService.getMasterSecret(context), messageAndThreadId.second, true);
+      }
     } else if (message.isPresent()) {
       Log.w(TAG, "*** Received blocked SMS, ignoring...");
     }

--- a/src/org/smssecure/smssecure/notifications/MessageNotifier.java
+++ b/src/org/smssecure/smssecure/notifications/MessageNotifier.java
@@ -132,19 +132,35 @@ public class MessageNotifier {
     }
   }
 
-  public static void updateNotificationWithFlags(Context context, MasterSecret masterSecret, int flags) {
+  public static void updateNotificationWithFlags(Context context, MasterSecret masterSecret, int flags, boolean vibrate) {
     if (!SilencePreferences.isNotificationsEnabled(context)) {
       return;
     }
 
-    updateNotification(context, masterSecret, flags, 0);
+    updateNotification(context, masterSecret, flags, 0, vibrate);
+  }
+
+  public static void updateNotificationWithFlags(Context context, MasterSecret masterSecret, int flags) {
+    updateNotificationWithFlags(context, masterSecret, flags, false);
+  }
+
+  public static void updateNotification(Context context, MasterSecret masterSecret, boolean vibrate) {
+    updateNotificationWithFlags(context, masterSecret, MNF_LIGHTS_KEEP, vibrate);
   }
 
   public static void updateNotification(Context context, MasterSecret masterSecret) {
-    updateNotificationWithFlags(context, masterSecret, MNF_LIGHTS_KEEP);
+    updateNotificationWithFlags(context, masterSecret, MNF_LIGHTS_KEEP, false);
   }
 
   public static void updateNotification(Context context, MasterSecret masterSecret, long threadId) {
+    updateNotification(context, masterSecret, threadId, false);
+  }
+
+  public static void updateNotification(Context context, MasterSecret masterSecret, long threadId, boolean vibrate) {
+    updateNotification(context, masterSecret, MNF_DEFAULTS, threadId, vibrate);
+  }
+
+  public static void updateNotification(Context context, MasterSecret masterSecret, int flags, long threadId, boolean vibrate) {
     boolean    isVisible  = visibleThread == threadId;
 
     ThreadDatabase threads    = DatabaseFactory.getThreadDatabase(context);
@@ -164,11 +180,11 @@ public class MessageNotifier {
     if (isVisible) {
       sendInThreadNotification(context, threads.getRecipientsForThreadId(threadId));
     } else {
-      updateNotification(context, masterSecret, MNF_DEFAULTS, 0);
+      updateNotification(context, masterSecret, flags, 0, vibrate);
     }
   }
 
-  private static void updateNotification(Context context, MasterSecret masterSecret, int flags, int reminderCount) {
+  private static void updateNotification(Context context, MasterSecret masterSecret, int flags, int reminderCount, boolean vibrate) {
     Cursor telcoCursor = null;
     Cursor pushCursor  = null;
 
@@ -186,9 +202,9 @@ public class MessageNotifier {
       NotificationState notificationState = constructNotificationState(context, masterSecret, telcoCursor);
 
       if (notificationState.hasMultipleThreads()) {
-        sendMultipleThreadNotification(context, notificationState, flags);
+        sendMultipleThreadNotification(context, notificationState, flags, vibrate);
       } else {
-        sendSingleThreadNotification(context, masterSecret, notificationState, flags);
+        sendSingleThreadNotification(context, masterSecret, notificationState, flags, vibrate);
       }
 
       if (newNotificationRequested(flags)) {
@@ -215,7 +231,8 @@ public class MessageNotifier {
   private static void sendSingleThreadNotification(Context context,
                                                    MasterSecret masterSecret,
                                                    NotificationState notificationState,
-                                                   int flags)
+                                                   int flags,
+                                                   boolean vibrate)
   {
     if (notificationState.getNotifications().isEmpty()) {
       cancelNotification(context);
@@ -250,6 +267,7 @@ public class MessageNotifier {
     if (notificationsRequested(flags)) {
       triggerNotificationAlarms(builder, notificationState, flags);
 
+      if (vibrate) builder.setAudibleAlarms(notificationState.getRingtone(), notificationState.getVibrate());
       builder.setTicker(notifications.get(0).getIndividualRecipient(),
                         notifications.get(0).getText());
     }
@@ -260,7 +278,8 @@ public class MessageNotifier {
 
   private static void sendMultipleThreadNotification(Context context,
                                                      NotificationState notificationState,
-                                                     int flags)
+                                                     int flags,
+                                                     boolean vibrate)
   {
     MultipleRecipientNotificationBuilder builder       = new MultipleRecipientNotificationBuilder(context, SilencePreferences.getNotificationPrivacy(context));
     List<NotificationItem>               notifications = notificationState.getNotifications();
@@ -283,6 +302,7 @@ public class MessageNotifier {
     if (notificationsRequested(flags)) {
       triggerNotificationAlarms(builder, notificationState, flags);
 
+      if (vibrate) builder.setAudibleAlarms(notificationState.getRingtone(), notificationState.getVibrate());
       builder.setTicker(notifications.get(0).getIndividualRecipient(),
                         notifications.get(0).getText());
     }
@@ -417,7 +437,7 @@ public class MessageNotifier {
         protected Void doInBackground(Void... params) {
           MasterSecret masterSecret  = KeyCachingService.getMasterSecret(context);
           int          reminderCount = intent.getIntExtra("reminder_count", 0);
-          MessageNotifier.updateNotification(context, masterSecret, MNF_DEFAULTS, reminderCount + 1);
+          MessageNotifier.updateNotification(context, masterSecret, MNF_DEFAULTS, reminderCount + 1, false);
 
           return null;
         }


### PR DESCRIPTION
### Fix notification vibration in Android N

Before this PR, a notification is displayed when encrypted message arrives then updated when it is decrypted. The issue remains in the way notifications are updated: the previous one is cancelled and replaced with a new one that contains the decrypted message.

In Android < 7.0, phone will vibrate even if notification is cancelled. Not in Nougat: vibration is stopped if notification is cancelled. That results in no (or very short) vibration for encrypted messages because notification is quickly replaced.

This PR delays notification for encrypted messages. Decryption job is very short (not assessable even on an old N5), so it won't impact usability.

Fixes #447