### PR TITLE
unbreak notification light for encrypted messages

### DIFF
--- a/src/org/smssecure/smssecure/jobs/SmsDecryptJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsDecryptJob.java
@@ -80,7 +80,7 @@ public class SmsDecryptJob extends MasterSecretJob {
       else if (message.isXmppExchange())  handleXmppExchangeMessage(masterSecret, messageId, threadId, (IncomingXmppExchangeMessage) message);
       else                                database.updateMessageBody(masterSecret, messageId, message.getMessageBody());
 
-      MessageNotifier.updateNotification(context, masterSecret, MessageNotifier.MNF_LIGHTS_KEEP, threadId, true);
+      MessageNotifier.updateNotification(context, masterSecret, MessageNotifier.MNF_DEFAULTS, threadId, true);
     } catch (LegacyMessageException e) {
       Log.w(TAG, e);
       database.markAsLegacyVersion(messageId);


### PR DESCRIPTION
### Unbreak notification lights for encrypted messages

dc84d124f860e9de2f9f1a5c435897a2b77e5bed changed the way notifications are shown for encrypted messages. Flag to manage light is incorrect and results in no notification light. This PR fixes that.