### PR TITLE
Display notification if app is locked

### DIFF
--- a/src/org/smssecure/smssecure/jobs/SmsReceiveJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsReceiveJob.java
@@ -53,13 +53,15 @@ public class SmsReceiveJob extends ContextJob {
 
     if (message.isPresent() && !isBlocked(message.get())) {
       Pair<Long, Long> messageAndThreadId = storeMessage(message.get());
+      MasterSecret masterSecret = KeyCachingService.getMasterSecret(context);
 
       IncomingTextMessage incomingTextMessage = message.get();
-      if (!incomingTextMessage.isSecureMessage() &&
-          !incomingTextMessage.isKeyExchange()   &&
-          !incomingTextMessage.isXmppExchange())
+      if (masterSecret == null                     ||
+          (!incomingTextMessage.isSecureMessage()  &&
+           !incomingTextMessage.isKeyExchange()    &&
+           !incomingTextMessage.isXmppExchange()))
       {
-        MessageNotifier.updateNotification(context, KeyCachingService.getMasterSecret(context), messageAndThreadId.second, true);
+        MessageNotifier.updateNotification(context, masterSecret, messageAndThreadId.second, true);
       }
     } else if (message.isPresent()) {
       Log.w(TAG, "*** Received blocked SMS, ignoring...");


### PR DESCRIPTION
### Display notification if app is locked

dc84d124f860e9de2f9f1a5c435897a2b77e5bed introduced a new way to manage notifications for encrypted messages, but it results in no notifications when device is locked (because message is not decrypted yet). This PR displays a notification when device is locked, even if it is an encrypted message.

Fixes #485