### PR TITLE
Do not vibrate when message is decrypted and Silence was locked

### DIFF
--- a/src/org/smssecure/smssecure/ReceiveKeyDialog.java
+++ b/src/org/smssecure/smssecure/ReceiveKeyDialog.java
@@ -205,7 +205,7 @@ public class ReceiveKeyDialog extends AlertDialog {
           } else {
             ApplicationContext.getInstance(getContext())
                     .getJobManager()
-                    .add(new SmsDecryptJob(context, messageRecord.getId(), true));
+                    .add(new SmsDecryptJob(context, messageRecord.getId(), true, false));
           }
           return null;
         }

--- a/src/org/smssecure/smssecure/notifications/AbstractNotificationBuilder.java
+++ b/src/org/smssecure/smssecure/notifications/AbstractNotificationBuilder.java
@@ -38,15 +38,16 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
     return builder;
   }
 
-  public void setAudibleAlarms(@Nullable Uri ringtone, RecipientPreferenceDatabase.VibrateState vibrate) {
+  public void setAudibleAlarms(@Nullable Uri ringtone, @Nullable RecipientPreferenceDatabase.VibrateState vibrate) {
     String defaultRingtoneName   = SilencePreferences.getNotificationRingtone(context);
     boolean defaultVibrate       = SilencePreferences.isNotificationVibrateEnabled(context);
 
     if      (ringtone != null)                        setSound(ringtone);
     else if (!TextUtils.isEmpty(defaultRingtoneName)) setSound(Uri.parse(defaultRingtoneName));
 
-    if (vibrate == RecipientPreferenceDatabase.VibrateState.ENABLED ||
-        (vibrate == RecipientPreferenceDatabase.VibrateState.DEFAULT && defaultVibrate))
+    if (vibrate != null &&
+        (vibrate == RecipientPreferenceDatabase.VibrateState.ENABLED ||
+        (vibrate == RecipientPreferenceDatabase.VibrateState.DEFAULT && defaultVibrate)))
     {
       setDefaults(Notification.DEFAULT_VIBRATE);
     }

--- a/src/org/smssecure/smssecure/notifications/MessageNotifier.java
+++ b/src/org/smssecure/smssecure/notifications/MessageNotifier.java
@@ -199,12 +199,12 @@ public class MessageNotifier {
         return;
       }
 
-      NotificationState notificationState = constructNotificationState(context, masterSecret, telcoCursor);
+      NotificationState notificationState = constructNotificationState(context, masterSecret, telcoCursor, vibrate);
 
       if (notificationState.hasMultipleThreads()) {
-        sendMultipleThreadNotification(context, notificationState, flags, vibrate);
+        sendMultipleThreadNotification(context, notificationState, flags);
       } else {
-        sendSingleThreadNotification(context, masterSecret, notificationState, flags, vibrate);
+        sendSingleThreadNotification(context, masterSecret, notificationState, flags);
       }
 
       if (newNotificationRequested(flags)) {
@@ -231,8 +231,7 @@ public class MessageNotifier {
   private static void sendSingleThreadNotification(Context context,
                                                    MasterSecret masterSecret,
                                                    NotificationState notificationState,
-                                                   int flags,
-                                                   boolean vibrate)
+                                                   int flags)
   {
     if (notificationState.getNotifications().isEmpty()) {
       cancelNotification(context);
@@ -267,7 +266,6 @@ public class MessageNotifier {
     if (notificationsRequested(flags)) {
       triggerNotificationAlarms(builder, notificationState, flags);
 
-      if (vibrate) builder.setAudibleAlarms(notificationState.getRingtone(), notificationState.getVibrate());
       builder.setTicker(notifications.get(0).getIndividualRecipient(),
                         notifications.get(0).getText());
     }
@@ -278,8 +276,7 @@ public class MessageNotifier {
 
   private static void sendMultipleThreadNotification(Context context,
                                                      NotificationState notificationState,
-                                                     int flags,
-                                                     boolean vibrate)
+                                                     int flags)
   {
     MultipleRecipientNotificationBuilder builder       = new MultipleRecipientNotificationBuilder(context, SilencePreferences.getNotificationPrivacy(context));
     List<NotificationItem>               notifications = notificationState.getNotifications();
@@ -302,7 +299,6 @@ public class MessageNotifier {
     if (notificationsRequested(flags)) {
       triggerNotificationAlarms(builder, notificationState, flags);
 
-      if (vibrate) builder.setAudibleAlarms(notificationState.getRingtone(), notificationState.getVibrate());
       builder.setTicker(notifications.get(0).getIndividualRecipient(),
                         notifications.get(0).getText());
     }
@@ -361,11 +357,14 @@ public class MessageNotifier {
 
   private static NotificationState constructNotificationState(Context context,
                                                               MasterSecret masterSecret,
-                                                              Cursor cursor)
+                                                              Cursor cursor,
+                                                              boolean vibrate)
   {
     NotificationState notificationState = new NotificationState();
     MessageRecord record;
     MmsSmsDatabase.Reader reader;
+
+    notificationState.setVibrate(vibrate);
 
     if (masterSecret == null) reader = DatabaseFactory.getMmsSmsDatabase(context).readerFor(cursor);
     else                      reader = DatabaseFactory.getMmsSmsDatabase(context).readerFor(cursor, masterSecret);

--- a/src/org/smssecure/smssecure/notifications/NotificationState.java
+++ b/src/org/smssecure/smssecure/notifications/NotificationState.java
@@ -21,8 +21,13 @@ public class NotificationState {
 
   private final LinkedList<NotificationItem> notifications = new LinkedList<>();
   private final Set<Long>                    threads       = new HashSet<>();
+  private       boolean                      vibrate       = true;
 
   private int notificationCount = 0;
+
+  public void setVibrate(boolean vibrate) {
+    this.vibrate = vibrate;
+  }
 
   public void addNotification(NotificationItem item) {
     notifications.addFirst(item);
@@ -42,7 +47,8 @@ public class NotificationState {
     return null;
   }
 
-  public VibrateState getVibrate() {
+  public @Nullable VibrateState getVibrate() {
+    if (!vibrate) return null;
     if (!notifications.isEmpty()) {
       Recipients recipients = notifications.getFirst().getRecipients();
 

--- a/src/org/smssecure/smssecure/sms/IncomingTextMessage.java
+++ b/src/org/smssecure/smssecure/sms/IncomingTextMessage.java
@@ -34,8 +34,13 @@ public class IncomingTextMessage implements Parcelable {
   private final String  groupId;
   private final boolean push;
   private final int     subscriptionId;
+  private final boolean receivedWhenLocked;
 
   public IncomingTextMessage(SmsMessage message, int subscriptionId) {
+    this(message, subscriptionId, false);
+  }
+
+  public IncomingTextMessage(SmsMessage message, int subscriptionId, boolean receivedWhenLocked) {
     this.message              = message.getDisplayMessageBody();
     this.sender               = message.getDisplayOriginatingAddress();
     this.senderDeviceId       = 1;
@@ -47,6 +52,7 @@ public class IncomingTextMessage implements Parcelable {
     this.subscriptionId       = subscriptionId;
     this.groupId              = null;
     this.push                 = false;
+    this.receivedWhenLocked   = receivedWhenLocked;
   }
 
   public IncomingTextMessage(String sender, int senderDeviceId, long sentTimestampMillis, String encodedBody) {
@@ -61,6 +67,7 @@ public class IncomingTextMessage implements Parcelable {
     this.push                 = true;
     this.subscriptionId       = -1;
     this.groupId = null;
+    this.receivedWhenLocked   = false;
   }
 
   public IncomingTextMessage(Parcel in) {
@@ -75,6 +82,7 @@ public class IncomingTextMessage implements Parcelable {
     this.groupId              = in.readString();
     this.push                 = (in.readInt() == 1);
     this.subscriptionId       = in.readInt();
+    this.receivedWhenLocked   = (in.readInt() == 1);
   }
 
   public IncomingTextMessage(IncomingTextMessage base, String newBody) {
@@ -89,6 +97,7 @@ public class IncomingTextMessage implements Parcelable {
     this.groupId              = base.getGroupId();
     this.push                 = base.isPush();
     this.subscriptionId       = base.getSubscriptionId();
+    this.receivedWhenLocked   = base.isReceivedWhenLocked();
   }
 
   public IncomingTextMessage(List<IncomingTextMessage> fragments) {
@@ -109,6 +118,7 @@ public class IncomingTextMessage implements Parcelable {
     this.groupId              = fragments.get(0).getGroupId();
     this.push                 = fragments.get(0).isPush();
     this.subscriptionId       = fragments.get(0).getSubscriptionId();
+    this.receivedWhenLocked   = fragments.get(0).isReceivedWhenLocked();
   }
 
   protected IncomingTextMessage(String sender, String groupId)
@@ -124,6 +134,7 @@ public class IncomingTextMessage implements Parcelable {
     this.groupId              = groupId;
     this.push                 = true;
     this.subscriptionId       = -1;
+    this.receivedWhenLocked   = false;
   }
 
   public int getSubscriptionId() {
@@ -198,6 +209,10 @@ public class IncomingTextMessage implements Parcelable {
     return false;
   }
 
+  public boolean isReceivedWhenLocked() {
+    return receivedWhenLocked;
+  }
+
   @Override
   public int describeContents() {
     return 0;
@@ -216,5 +231,6 @@ public class IncomingTextMessage implements Parcelable {
     out.writeString(groupId);
     out.writeInt(push ? 1 : 0);
     out.writeInt(subscriptionId);
+    out.writeInt(receivedWhenLocked ? 1 : 0);
   }
 }


### PR DESCRIPTION
#486 was an hotfix for an issue with notification, but it introduced a minor glitch: when Silence is unlocked, notification is updated and phone vibrates another time. This PR removes the second vibration.