### PR TITLE
Do not rebuild notification when Silence is unlock

### DIFF
--- a/src/org/smssecure/smssecure/jobs/SmsDecryptJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsDecryptJob.java
@@ -88,7 +88,11 @@ public class SmsDecryptJob extends MasterSecretJob {
       else if (message.isXmppExchange())  handleXmppExchangeMessage(masterSecret, messageId, threadId, (IncomingXmppExchangeMessage) message);
       else                                database.updateMessageBody(masterSecret, messageId, message.getMessageBody());
 
-      MessageNotifier.updateNotification(context, masterSecret, MessageNotifier.MNF_DEFAULTS, threadId, !isReceivedWhenLocked);
+      if (!isReceivedWhenLocked) {
+        MessageNotifier.updateNotification(context, masterSecret, MessageNotifier.MNF_LIGHTS_KEEP);
+      } else {
+        MessageNotifier.updateNotification(context, masterSecret);
+      }
     } catch (LegacyMessageException e) {
       Log.w(TAG, e);
       database.markAsLegacyVersion(messageId);

--- a/src/org/smssecure/smssecure/jobs/SmsReceiveJob.java
+++ b/src/org/smssecure/smssecure/jobs/SmsReceiveJob.java
@@ -61,7 +61,7 @@ public class SmsReceiveJob extends ContextJob {
           !incomingTextMessage.isKeyExchange()       &&
           !incomingTextMessage.isXmppExchange()))
       {
-        MessageNotifier.updateNotification(context, masterSecret, messageAndThreadId.second, true);
+        MessageNotifier.updateNotification(context, masterSecret, messageAndThreadId.second);
       }
     } else if (message.isPresent()) {
       Log.w(TAG, "*** Received blocked SMS, ignoring...");

--- a/src/org/smssecure/smssecure/notifications/MessageNotifier.java
+++ b/src/org/smssecure/smssecure/notifications/MessageNotifier.java
@@ -134,35 +134,19 @@ public class MessageNotifier {
     }
   }
 
-  public static void updateNotificationWithFlags(Context context, MasterSecret masterSecret, int flags, boolean vibrate) {
+  private static void updateNotificationWithFlags(Context context, MasterSecret masterSecret, int flags) {
     if (!SilencePreferences.isNotificationsEnabled(context)) {
       return;
     }
 
-    updateNotification(context, masterSecret, flags, 0, vibrate);
-  }
-
-  public static void updateNotificationWithFlags(Context context, MasterSecret masterSecret, int flags) {
-    updateNotificationWithFlags(context, masterSecret, flags, false);
-  }
-
-  public static void updateNotification(Context context, MasterSecret masterSecret, boolean vibrate) {
-    updateNotificationWithFlags(context, masterSecret, MNF_LIGHTS_KEEP, vibrate);
+    updateNotification(context, masterSecret, flags, 0);
   }
 
   public static void updateNotification(Context context, MasterSecret masterSecret) {
-    updateNotificationWithFlags(context, masterSecret, MNF_LIGHTS_KEEP, false);
+    updateNotificationWithFlags(context, masterSecret, MNF_LIGHTS_KEEP);
   }
 
   public static void updateNotification(Context context, MasterSecret masterSecret, long threadId) {
-    updateNotification(context, masterSecret, threadId, false);
-  }
-
-  public static void updateNotification(Context context, MasterSecret masterSecret, long threadId, boolean vibrate) {
-    updateNotification(context, masterSecret, MNF_DEFAULTS, threadId, vibrate);
-  }
-
-  public static void updateNotification(Context context, MasterSecret masterSecret, int flags, long threadId, boolean vibrate) {
     boolean    isVisible  = visibleThread == threadId;
 
     ThreadDatabase threads    = DatabaseFactory.getThreadDatabase(context);
@@ -182,11 +166,11 @@ public class MessageNotifier {
     if (isVisible) {
       sendInThreadNotification(context, threads.getRecipientsForThreadId(threadId));
     } else {
-      updateNotification(context, masterSecret, flags, 0, vibrate);
+      updateNotification(context, masterSecret, MNF_DEFAULTS, 0);
     }
   }
 
-  private static void updateNotification(Context context, MasterSecret masterSecret, int flags, int reminderCount, boolean vibrate) {
+  private static void updateNotification(Context context, MasterSecret masterSecret, int flags, int reminderCount) {
     Cursor telcoCursor = null;
     Cursor pushCursor  = null;
 
@@ -202,7 +186,7 @@ public class MessageNotifier {
         return;
       }
 
-      NotificationState notificationState = constructNotificationState(context, masterSecret, telcoCursor, vibrate);
+      NotificationState notificationState = constructNotificationState(context, masterSecret, telcoCursor);
 
       if (notificationState.hasMultipleThreads()) {
         sendMultipleThreadNotification(context, notificationState, flags);
@@ -362,14 +346,11 @@ public class MessageNotifier {
 
   private static NotificationState constructNotificationState(Context context,
                                                               MasterSecret masterSecret,
-                                                              Cursor cursor,
-                                                              boolean vibrate)
+                                                              Cursor cursor)
   {
     NotificationState notificationState = new NotificationState();
     MessageRecord record;
     MmsSmsDatabase.Reader reader;
-
-    notificationState.setVibrate(vibrate);
 
     if (masterSecret == null) reader = DatabaseFactory.getMmsSmsDatabase(context).readerFor(cursor);
     else                      reader = DatabaseFactory.getMmsSmsDatabase(context).readerFor(cursor, masterSecret);
@@ -441,7 +422,7 @@ public class MessageNotifier {
         protected Void doInBackground(Void... params) {
           MasterSecret masterSecret  = KeyCachingService.getMasterSecret(context);
           int          reminderCount = intent.getIntExtra("reminder_count", 0);
-          MessageNotifier.updateNotification(context, masterSecret, MNF_DEFAULTS, reminderCount + 1, false);
+          MessageNotifier.updateNotification(context, masterSecret, MNF_DEFAULTS, reminderCount + 1);
 
           return null;
         }

--- a/src/org/smssecure/smssecure/notifications/NotificationState.java
+++ b/src/org/smssecure/smssecure/notifications/NotificationState.java
@@ -21,13 +21,8 @@ public class NotificationState {
 
   private final LinkedList<NotificationItem> notifications = new LinkedList<>();
   private final Set<Long>                    threads       = new HashSet<>();
-  private       boolean                      vibrate       = true;
 
   private int notificationCount = 0;
-
-  public void setVibrate(boolean vibrate) {
-    this.vibrate = vibrate;
-  }
 
   public void addNotification(NotificationItem item) {
     notifications.addFirst(item);
@@ -47,8 +42,7 @@ public class NotificationState {
     return null;
   }
 
-  public @Nullable VibrateState getVibrate() {
-    if (!vibrate) return null;
+  public VibrateState getVibrate() {
     if (!notifications.isEmpty()) {
       Recipients recipients = notifications.getFirst().getRecipients();
 


### PR DESCRIPTION
## Description

When Silence is unlocked, notification is not updated but rebuilt. This causes a new sound, vibration and display. This PR just updates the notification instead of rebuilding it.

Tested with encrypted and unencrypted messages on Android 7.1.1.

Fixes #490.