### PR TITLE
Removed duplicate notification for MMS

### DIFF
--- a/src/org/smssecure/smssecure/jobs/MmsDownloadJob.java
+++ b/src/org/smssecure/smssecure/jobs/MmsDownloadJob.java
@@ -229,7 +229,7 @@ public class MmsDownloadJob extends MasterSecretJob {
     }
 
     database.delete(messageId);
-    MessageNotifier.updateNotification(context, masterSecret, messageAndThreadId.second);
+    MessageNotifier.updateNotification(context, null);
   }
 
   private void handleDownloadError(MasterSecret masterSecret, long messageId, long threadId,

--- a/src/org/smssecure/smssecure/jobs/MmsReceiveJob.java
+++ b/src/org/smssecure/smssecure/jobs/MmsReceiveJob.java
@@ -67,6 +67,7 @@ public class MmsReceiveJob extends ContextJob {
       Log.w(TAG, "Inserted received MMS notification...");
 
       database.markIncomingNotificationReceived(messageAndThreadId.second);
+      MessageNotifier.updateNotification(context, masterSecret, messageAndThreadId.second);
 
       ApplicationContext.getInstance(context)
                         .getJobManager()

--- a/src/org/smssecure/smssecure/jobs/MmsReceiveJob.java
+++ b/src/org/smssecure/smssecure/jobs/MmsReceiveJob.java
@@ -67,7 +67,6 @@ public class MmsReceiveJob extends ContextJob {
       Log.w(TAG, "Inserted received MMS notification...");
 
       database.markIncomingNotificationReceived(messageAndThreadId.second);
-      MessageNotifier.updateNotification(context, masterSecret, messageAndThreadId.second);
 
       ApplicationContext.getInstance(context)
                         .getJobManager()


### PR DESCRIPTION
<!-- Please ensure that:
- You are requesting `unstable` as base branch
- You have followed the Code Style Guidelines: https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines
- Your contribution is ready to be merged as is
-->

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works and the devices you tested it on.
-->
Removes the initial MMS notification.  A notification is created later when the message download succeeds/fails.  
Fixes #524 