### PR TITLE
spelling error corrected

### DIFF
--- a/res/values-de/distribution-strings.xml
+++ b/res/values-de/distribution-strings.xml
@@ -2,9 +2,9 @@
 <resources>
   <string name="Distribution_title">Silence</string>
   <string name="Distribution_tagline">SMS/MMS-Verschlüsselung leicht gemacht!</string>
-  <string name="Distribution_description">Silence ist eine SMS/MMS-Anwendung zum Schutz Ihrer Privatspäre bei der Kommunikation mit Ihren Freunden.</string>
+  <string name="Distribution_description">Silence ist eine SMS/MMS-Anwendung zum Schutz Ihrer Privatsphäre bei der Kommunikation mit Ihren Freunden.</string>
   <string name="Distribution_long_description">
-Silence ist eine SMS/MMS-Anwendung zum Schutz deiner Privatspäre bei der Kommunikation mit Freunden.
+Silence ist eine SMS/MMS-Anwendung zum Schutz deiner Privatsphäre bei der Kommunikation mit Freunden.
 Mit Silence kannst du SMS-Nachrichten senden sowie Medien oder Anhänge teilen unter vollständiger Einhaltung deiner Privatsphäre.
 
 Funktionen:


### PR DESCRIPTION
wrong: `Privatspäre`  
correct: `Privatsphäre`