### PR TITLE
Allow usage of system emoji instead of built-in support

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -758,6 +758,8 @@
     <string name="preferences__roaming_auto_retrieve">Roaming auto-retrieve</string>
     <string name="preferences__automatically_retrieve_mms_when_roaming">Automatically retrieve MMS when roaming</string>
     <string name="preferences_chats__message_trimming">Message trimming</string>
+    <string name="preferences_advanced__use_system_emoji">Use system emoji</string>
+    <string name="preferences_advanced__disable_silences_built_in_emoji_support">Make Silence blob again! Disable Silence\'s built-in emoji support</string>
 
     <!-- **************************************** -->
     <!-- menus -->

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -20,6 +20,12 @@
                         android:title="@string/preferences__complete_key_exchanges"
                         android:summary="@string/preferences__automatically_complete_key_exchanges_for_new_sessions_or_for_existing_sessions_with_the_same_identity_key" />
 
+    <org.smssecure.smssecure.components.SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="pref_system_emoji"
+        android:title="@string/preferences_advanced__use_system_emoji"
+        android:summary="@string/preferences_advanced__disable_silences_built_in_emoji_support" />
+
     <Preference android:key="pref_submit_debug_logs"
                 android:title="@string/preferences__submit_debug_log"/>
 </PreferenceScreen>

--- a/src/org/smssecure/smssecure/ConversationActivity.java
+++ b/src/org/smssecure/smssecure/ConversationActivity.java
@@ -947,17 +947,21 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     SendButtonListener        sendButtonListener        = new SendButtonListener();
     ComposeKeyPressedListener composeKeyPressedListener = new ComposeKeyPressedListener();
 
-    emojiToggle.attach(emojiDrawerStub.get());
-    emojiToggle.setOnClickListener(new EmojiToggleListener());
-    emojiDrawerStub.get().setEmojiEventListener(new EmojiEventListener() {
-      @Override public void onKeyEvent(KeyEvent keyEvent) {
-        composeText.dispatchKeyEvent(keyEvent);
+    if (SilencePreferences.isSystemEmojiPreferred(this)) {
+      emojiToggle.setVisibility(View.GONE);
+    } else {
+      emojiToggle.attach(emojiDrawerStub.get());
+      emojiToggle.setOnClickListener(new EmojiToggleListener());
+      emojiDrawerStub.get().setEmojiEventListener(new EmojiEventListener() {
+        @Override public void onKeyEvent(KeyEvent keyEvent) {
+          composeText.dispatchKeyEvent(keyEvent);
+        }
       }
 
       @Override public void onEmojiSelected(String emoji) {
         composeText.insertEmoji(emoji);
-      }
-    });
+      });
+    }
 
     composeText.setOnEditorActionListener(sendButtonListener);
     attachButton.setOnClickListener(new AttachButtonListener());

--- a/src/org/smssecure/smssecure/ConversationActivity.java
+++ b/src/org/smssecure/smssecure/ConversationActivity.java
@@ -956,10 +956,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         @Override public void onKeyEvent(KeyEvent keyEvent) {
           composeText.dispatchKeyEvent(keyEvent);
         }
-      }
 
-      @Override public void onEmojiSelected(String emoji) {
-        composeText.insertEmoji(emoji);
+        @Override public void onEmojiSelected(String emoji) {
+          composeText.insertEmoji(emoji);
+        }
       });
     }
 

--- a/src/org/smssecure/smssecure/components/emoji/EmojiEditText.java
+++ b/src/org/smssecure/smssecure/components/emoji/EmojiEditText.java
@@ -10,6 +10,7 @@ import android.util.AttributeSet;
 
 import org.smssecure.smssecure.R;
 import org.smssecure.smssecure.components.emoji.EmojiProvider.EmojiDrawable;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 
 public class EmojiEditText extends AppCompatEditText {
@@ -25,7 +26,9 @@ public class EmojiEditText extends AppCompatEditText {
 
   public EmojiEditText(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
-    setFilters(appendEmojiFilter(this.getFilters()));
+    if (!SilencePreferences.isSystemEmojiPreferred(getContext())) {
+      setFilters(new InputFilter[]{ new EmojiFilter(this) });
+    }
   }
 
   public void insertEmoji(String emoji) {

--- a/src/org/smssecure/smssecure/components/emoji/EmojiTextView.java
+++ b/src/org/smssecure/smssecure/components/emoji/EmojiTextView.java
@@ -12,10 +12,12 @@ import android.util.AttributeSet;
 
 import org.smssecure.smssecure.components.emoji.EmojiProvider.EmojiDrawable;
 import org.smssecure.smssecure.util.ViewUtil;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 public class EmojiTextView extends AppCompatTextView {
   private CharSequence source;
   private boolean      needsEllipsizing;
+  private boolean      useSystemEmoji;
 
   public EmojiTextView(Context context) {
     this(context, null);
@@ -27,14 +29,19 @@ public class EmojiTextView extends AppCompatTextView {
 
   public EmojiTextView(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
+    this.useSystemEmoji = SilencePreferences.isSystemEmojiPreferred(getContext());
   }
 
   @Override public void setText(@Nullable CharSequence text, BufferType type) {
+    if (useSystemEmoji) {
+      super.setText(text, type);
+      return;
+    }
     source = EmojiProvider.getInstance(getContext()).emojify(text, this);
     setTextEllipsized(source);
   }
 
-  public void setTextEllipsized(final @Nullable CharSequence source) {
+  private void setTextEllipsized(final @Nullable CharSequence source) {
     super.setText(needsEllipsizing ? ViewUtil.ellipsize(source, this) : source, BufferType.SPANNABLE);
   }
 
@@ -46,7 +53,8 @@ public class EmojiTextView extends AppCompatTextView {
   @Override protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
     final int size = MeasureSpec.getSize(widthMeasureSpec);
     final int mode = MeasureSpec.getMode(widthMeasureSpec);
-    if (getEllipsize() == TruncateAt.END                             &&
+    if (!useSystemEmoji                                              &&
+        getEllipsize() == TruncateAt.END                             &&
         !TextUtils.isEmpty(source)                                   &&
         (mode == MeasureSpec.AT_MOST || mode == MeasureSpec.EXACTLY) &&
         getPaint().breakText(source, 0, source.length()-1, true, size, null) != source.length())
@@ -62,7 +70,7 @@ public class EmojiTextView extends AppCompatTextView {
   }
 
   @Override protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-    if (changed) setTextEllipsized(source);
+    if (changed && !useSystemEmoji) setTextEllipsized(source);
     super.onLayout(changed, left, top, right, bottom);
   }
 }

--- a/src/org/smssecure/smssecure/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/smssecure/smssecure/preferences/AdvancedPreferenceFragment.java
@@ -20,6 +20,7 @@ import org.smssecure.smssecure.util.SilencePreferences;
 public class AdvancedPreferenceFragment extends ListSummaryPreferenceFragment {
   private static final String TAG = AdvancedPreferenceFragment.class.getSimpleName();
 
+  private static final String SYSTEM_EMOJI_PREF     = SilencePreferences.SYSTEM_EMOJI_PREF;
   private static final String SUBMIT_DEBUG_LOG_PREF = "pref_submit_debug_logs";
 
   @Override

--- a/src/org/smssecure/smssecure/util/SilencePreferences.java
+++ b/src/org/smssecure/smssecure/util/SilencePreferences.java
@@ -101,6 +101,8 @@ public class SilencePreferences {
   private static final String ICC_ID_FOR_APP_SUBSCRIPTION_ID_PREF                 = "icc_id_for_app_subscription_id";
   private static final String SUBSCRIPTIONS_PREF                                  = "pref_subscriptions";
 
+  public  static final String SYSTEM_EMOJI_PREF                = "pref_system_emoji";
+
   public  static final String INCOGNITO_KEYBORAD_PREF          = "pref_incognito_keyboard";
 
   public static boolean isIncognitoKeyboardEnabled(Context context) {
@@ -528,6 +530,10 @@ public class SilencePreferences {
 
   public static int getThreadTrimLength(Context context) {
     return Integer.parseInt(getStringPreference(context, THREAD_TRIM_LENGTH, "500"));
+  }
+
+  public static boolean isSystemEmojiPreferred(Context context) {
+    return getBooleanPreference(context, SYSTEM_EMOJI_PREF, false);
   }
 
   public static boolean isMediaDownloadAllowed(Context context) {


### PR DESCRIPTION
### Description
As some users using Android 6 / 7 consider the new Android 8 emoji as ugly, here's an option to use system emoji instead of built-in emoji.

When switched on, this option deactivates the built-in emoji drawer, letting the user use the keyboard's emoji panel. Silence will render emoji using system ones.

This commit allows users to use other emoji sets (via Magisk modules per instance).
