### PR TITLE
Adding an option to disable the new message separator in conversation

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -752,6 +752,8 @@
     <string name="preferences_notifications__display_in_notifications">Display in notifications</string>
     <string name="preferences__show_sent_time">Show sent time</string>
     <string name="preferences__show_sent_time_instead_of_received_time_in_conversations">Show sent time instead of received time for incoming messages</string>
+    <string name="preferences__hide_unread_message_divider">Hide unread message divider</string>
+    <string name="preferences__hide_unread_message_divider_in_conversation">Hide the unread message divider in conversation</string>
     <string name="preferences_chats__mms">MMS</string>
     <string name="preferences__auto_retrieve">Auto-retrieve</string>
     <string name="preferences__automatically_retrieve_mms_messages">Automatically retrieve MMS messages</string>

--- a/res/xml/preferences_sms_mms.xml
+++ b/res/xml/preferences_sms_mms.xml
@@ -24,6 +24,12 @@
                         android:defaultValue="false" />
 
     <org.smssecure.smssecure.components.SwitchPreferenceCompat
+        android:key="pref_hide_unread_message_divider"
+        android:title="@string/preferences__hide_unread_message_divider"
+        android:summary="@string/preferences__hide_unread_message_divider_in_conversation"
+        android:defaultValue="false" />
+
+    <org.smssecure.smssecure.components.SwitchPreferenceCompat
                         android:defaultValue="false"
                         android:key="pref_delivery_report_sms"
                         android:summary="@string/preferences__request_a_delivery_report_for_each_sms_message_you_send"

--- a/src/org/smssecure/smssecure/ConversationFragment.java
+++ b/src/org/smssecure/smssecure/ConversationFragment.java
@@ -63,11 +63,13 @@ import org.smssecure.smssecure.mms.Slide;
 import org.smssecure.smssecure.recipients.RecipientFactory;
 import org.smssecure.smssecure.recipients.Recipients;
 import org.smssecure.smssecure.sms.MessageSender;
+import org.smssecure.smssecure.util.SilencePreferences;
 import org.smssecure.smssecure.util.task.ProgressDialogAsyncTask;
 import org.smssecure.smssecure.util.SaveAttachmentTask;
 import org.smssecure.smssecure.util.SaveAttachmentTask.Attachment;
 import org.smssecure.smssecure.util.StickyHeaderDecoration;
 import org.smssecure.smssecure.util.ViewUtil;
+import org.smssecure.smssecure.util.SilencePreferences;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -259,8 +261,11 @@ public class ConversationFragment extends Fragment
       list.removeItemDecoration(lastSeenDecoration);
     }
 
-    lastSeenDecoration = new ConversationAdapter.LastSeenHeader(getListAdapter(), lastSeen);
-    list.addItemDecoration(lastSeenDecoration);
+    final Context context = getActivity().getApplicationContext();
+    if(!SilencePreferences.hideUnreadMessageDivider(context)){
+      lastSeenDecoration = new ConversationAdapter.LastSeenHeader(getListAdapter(), lastSeen);
+      list.addItemDecoration(lastSeenDecoration);
+    }
   }
 
   private void handleCopyMessage(final Set<MessageRecord> messageRecords) {

--- a/src/org/smssecure/smssecure/util/SilencePreferences.java
+++ b/src/org/smssecure/smssecure/util/SilencePreferences.java
@@ -74,6 +74,7 @@ public class SilencePreferences {
   public  static final String REPEAT_ALERTS_PREF               = "pref_repeat_alerts";
   private static final String DISABLE_EMOJI_DRAWER             = "pref_disable_emoji_drawer";
   private static final String SHOW_SENT_TIME                   = "pref_show_sent_time";
+  private static final String HIDE_UNREAD_MESSAGE_DIVIDER      = "pref_hide_unread_message_divider";
 
   private static final String LOCAL_REGISTRATION_ID_PREF       = "pref_local_registration_id";
   private static final String FALLBACK_SMS_ALLOWED_PREF        = "pref_allow_sms_traffic_out";
@@ -557,6 +558,10 @@ public class SilencePreferences {
 
   public static boolean showSentTime(Context context) {
     return getBooleanPreference(context, SHOW_SENT_TIME, false);
+  }
+
+  public static boolean hideUnreadMessageDivider(Context context) {
+    return getBooleanPreference(context, HIDE_UNREAD_MESSAGE_DIVIDER, false);
   }
 
   public static int getLastAppSubscriptionId(Context context) {


### PR DESCRIPTION
### Description
Adding an option to the SMS/MMS preference section to hide the new message separator.

Closes #559
  