### PR TITLE
Emoji extractor improvement

### DIFF
--- a/scripts/emoji-extractor/TTF_memo.txt
+++ b/scripts/emoji-extractor/TTF_memo.txt
@@ -1,0 +1,7 @@
+TTF/OTF tables data
+
+name:							font metadata
+cmap.cmap_format_12:					name <-> unicode
+CBDT.strikedata.cbdt_format_18:				name <-> data
+CBLC.strike.eblc_index_sub_table_1:			id <-> name
+GSUB.LookupList.Lookup.LigatureSubst.LigatureSet:	name <-> components <-> glyph

--- a/scripts/emoji-extractor/emoji-extractor.py
+++ b/scripts/emoji-extractor/emoji-extractor.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-import binascii
 import argparse
+import binascii
+import io
 import shutil
 from pathlib import Path
 import xml.etree.ElementTree as ElementTree
@@ -27,11 +28,9 @@ path = Path(args.output)
 shutil.rmtree(path, ignore_errors=True)
 path.mkdir()
 
-font = TTFont(args.input)
-font.saveXML('.NotoColorEmoji.ttx')
-
-ttx = ElementTree.parse('.NotoColorEmoji.ttx').getroot()
-os.remove('.NotoColorEmoji.ttx')
+font_xml = io.StringIO()
+TTFont(args.input).saveXML(font_xml)
+ttx = ElementTree.fromstring(font_xml.getvalue())
 
 for element in ttx.find('CBDT').find('strikedata'):
     data = element.find('rawimagedata').text.split()

--- a/scripts/emoji-extractor/emoji-extractor.py
+++ b/scripts/emoji-extractor/emoji-extractor.py
@@ -31,16 +31,32 @@ font_xml = io.StringIO()
 TTFont(args.input).saveXML(font_xml)
 ttx = ElementTree.fromstring(font_xml.getvalue())
 
+def mass_rename(ligature_set_or_emoji):
+    cmap = ttx.find('cmap').find('cmap_format_12')
+    code = ''
+    for map_element in cmap:
+        if map_element.attrib['name'].lower() == ligature_set_or_emoji:
+            replace_s = '' if len(map_element.attrib['code']) > 4 else '00'
+            code = map_element.attrib['code'].replace('0x', replace_s)
+            rename('emoji_{}.png'.format(ligature_set_or_emoji),
+                   'emoji_u{}.png'.format(code))
+
+def rename(old_name, new_name):
+    print('Renaming {} to {}'.format(old_name, new_name))
+    try:
+        (path / old_name).rename(path / new_name)
+    except:
+        print('!! Cannot rename {}'.format(old_name))
+
 for element in ttx.find('CBDT').find('strikedata'):
     data = element.find('rawimagedata').text.split()
-    name = element.attrib['name'].lower()
-    name = name.replace('uni', 'u')
+    name = element.attrib['name'].lower().replace('uni', 'u')
     image_path = path / 'emoji_{}.png'.format(name)
     print('Extracting {}'.format(image_path.name))
     emoji = open(image_path, "wb")
     for char in data:
-            hexChar = binascii.unhexlify(char)
-            emoji.write(hexChar)
+        hexChar = binascii.unhexlify(char)
+        emoji.write(hexChar)
     emoji.close
 
 for ligature_set_xml in ttx.find('GSUB')\
@@ -54,45 +70,17 @@ for ligature_set_xml in ttx.find('GSUB')\
                 .replace(',', '_')\
                 .replace('uni', 'u')
             glyph = ligature_xml.attrib['glyph']
-            old_name = 'emoji_{}.png'.format(glyph)
-            new_name = 'emoji_{}_{}.png'.format(ligature_set, component)
-            print('Renaming {} to {}'.format(old_name, new_name))
-            try:
-                (path / old_name).rename(path / new_name)
-            except:
-                print('!! Cannot rename {}'.format(old_name))
+            rename('emoji_{}.png'.format(glyph),
+                   'emoji_{}_{}.png'.format(ligature_set, component))
     else:
-        cmap = ttx.find('cmap').find('cmap_format_12')
-        code = ''
-        for map_element in cmap:
-            if map_element.attrib['name'] == ligature_set:
-                replace_s = '' if len(map_element.attrib['code']) > 4 else '00'
-                code = map_element.attrib['code'].replace('0x', replace_s)
-                old_name = 'emoji_{}.png'.format(ligature_set)
-                try:
-                    (path / old_name).rename(path / 'emoji_u{}.png'.format(code))
-                except:
-                    print('!! Cannot rename {}'.format(old_name))
-        else:
-            if code == '':
-                print('Ignoring {}...'.format(ligature_set))
+        mass_rename(ligature_set)
 
 emojis = path.glob('*.png')
 for emoji in emojis:
     if not emoji.name.startswith('emoji_u'):
         emoji = emoji.with_name(emoji.name.replace('emoji_', '').replace('.png', ''))
         print('Fixing {}...'.format(emoji.name))
-        cmap = ttx.find('cmap').find('cmap_format_12')
-        code = ''
-        for map_element in cmap:
-            if map_element.attrib['name'].lower() == emoji:
-                replace_s = '' if len(map_element.attrib['code']) > 4 else '00'
-                code = map_element.attrib['code'].replace('0x', replace_s)
-                old_name = path / 'emoji_{}.png'.format(emoji)
-                try:
-                    (path / old_name).rename(path / 'emoji_u{}.png'.format(code))
-                except:
-                    print('!! Cannot fix _{}'.format(old_name))
+        mass_rename(emoji)
 
 # Some flags aren't correctly sorted
 trans_table = {
@@ -109,4 +97,7 @@ trans_table = {
 }
 
 for old, new in trans_table.items():
-    (path / 'emoji_u{}.png'.format(old)).rename(path / 'emoji_u{}.png'.format(new))
+    old_path = path / 'emoji_u{}.png'.format(old)
+    new_path = path / 'emoji_u{}.png'.format(new)
+    print('Renaming incorrect {} to {}'.format(old_path.name, new_path.name))
+    old_path.rename(new_path)

--- a/scripts/emoji-extractor/emoji-extractor.py
+++ b/scripts/emoji-extractor/emoji-extractor.py
@@ -9,7 +9,6 @@ import xml.etree.ElementTree as ElementTree
 
 from fontTools.ttLib import TTFont
 
-
 parser = argparse.ArgumentParser(
     prog='emoji-extractor',
     description="""Extract emojis from NotoColorEmoji.ttf. Requires FontTools.""")
@@ -36,27 +35,27 @@ for element in ttx.find('CBDT').find('strikedata'):
     data = element.find('rawimagedata').text.split()
     name = element.attrib['name'].lower()
     name = name.replace('uni', 'u')
-    imagePath = path / 'emoji_{}.png'.format(name)
-    print('Extracting {}'.format(imagePath.name))
-    emoji = open(imagePath, "wb")
+    image_path = path / 'emoji_{}.png'.format(name)
+    print('Extracting {}'.format(image_path.name))
+    emoji = open(image_path, "wb")
     for char in data:
             hexChar = binascii.unhexlify(char)
             emoji.write(hexChar)
     emoji.close
 
-for ligatureSetXml in ttx.find('GSUB')\
+for ligature_set_xml in ttx.find('GSUB')\
         .find('LookupList')\
         .find('Lookup')\
         .find('LigatureSubst'):
-    ligatureSet = ligatureSetXml.attrib['glyph'].lower().replace('uni', 'u')
-    if ligatureSet.startswith('u'):  # TODO: parse missing emojis
-        for ligatureXml in ligatureSetXml:
-            component = ligatureXml.attrib['components'].lower()\
+    ligature_set = ligature_set_xml.attrib['glyph'].lower().replace('uni', 'u')
+    if ligature_set.startswith('u'):  # TODO: parse missing emojis
+        for ligature_xml in ligature_set_xml:
+            component = ligature_xml.attrib['components'].lower()\
                 .replace(',', '_')\
                 .replace('uni', 'u')
-            glyph = ligatureXml.attrib['glyph']
+            glyph = ligature_xml.attrib['glyph']
             old_name = 'emoji_{}.png'.format(glyph)
-            new_name = 'emoji_{}_{}.png'.format(ligatureSet, component)
+            new_name = 'emoji_{}_{}.png'.format(ligature_set, component)
             print('Renaming {} to {}'.format(old_name, new_name))
             try:
                 (path / old_name).rename(path / new_name)
@@ -65,18 +64,18 @@ for ligatureSetXml in ttx.find('GSUB')\
     else:
         cmap = ttx.find('cmap').find('cmap_format_12')
         code = ''
-        for mapElement in cmap:
-            if mapElement.attrib['name'] == ligatureSet:
-                replace_s = '' if len(mapElement.attrib['code']) > 4 else '00'
-                code = mapElement.attrib['code'].replace('0x', replace_s)
-                old_name = 'emoji_{}.png'.format(ligatureSet)
+        for map_element in cmap:
+            if map_element.attrib['name'] == ligature_set:
+                replace_s = '' if len(map_element.attrib['code']) > 4 else '00'
+                code = map_element.attrib['code'].replace('0x', replace_s)
+                old_name = 'emoji_{}.png'.format(ligature_set)
                 try:
                     (path / old_name).rename(path / 'emoji_u{}.png'.format(code))
                 except:
                     print('!! Cannot rename {}'.format(old_name))
         else:
             if code == '':
-                print('Ignoring {}...'.format(ligatureSet))
+                print('Ignoring {}...'.format(ligature_set))
 
 emojis = path.glob('*.png')
 for emoji in emojis:
@@ -85,10 +84,10 @@ for emoji in emojis:
         print('Fixing {}...'.format(emoji.name))
         cmap = ttx.find('cmap').find('cmap_format_12')
         code = ''
-        for mapElement in cmap:
-            if mapElement.attrib['name'].lower() == emoji:
-                replace_s = '' if len(mapElement.attrib['code']) > 4 else '00'
-                code = mapElement.attrib['code'].replace('0x', replace_s)
+        for map_element in cmap:
+            if map_element.attrib['name'].lower() == emoji:
+                replace_s = '' if len(map_element.attrib['code']) > 4 else '00'
+                code = map_element.attrib['code'].replace('0x', replace_s)
                 old_name = path / 'emoji_{}.png'.format(emoji)
                 try:
                     (path / old_name).rename(path / 'emoji_u{}.png'.format(code))

--- a/scripts/emoji-extractor/emoji-extractor.py
+++ b/scripts/emoji-extractor/emoji-extractor.py
@@ -8,9 +8,18 @@ import xml.etree.ElementTree as ElementTree
 import binascii
 import glob
 
-parser = argparse.ArgumentParser(prog='emoji-extractor', description="""Extract emojis from NotoColorEmoji.ttf. Requires FontTools.""")
-parser.add_argument('-i', '--input', help='the TTF file to parse', default='NotoColorEmoji.ttf', required=False)
-parser.add_argument('-o', '--output', help='the png output folder', default='output/', required=False)
+parser = argparse.ArgumentParser(
+    prog='emoji-extractor',
+    description="""Extract emojis from NotoColorEmoji.ttf. Requires FontTools.""")
+parser.add_argument(
+    '-i', '--input',
+    help='the TTF file to parse',
+    default='NotoColorEmoji.ttf',
+    required=False)
+parser.add_argument(
+    '-o', '--output',
+    help='the png output folder',
+    default='output/', required=False)
 args = parser.parse_args()
 
 try:
@@ -40,9 +49,12 @@ for element in ttx.find('CBDT').find('strikedata'):
 
 for ligatureSetXml in ttx.find('GSUB').find('LookupList').find('Lookup').find('LigatureSubst'):
     ligatureSet = ligatureSetXml.attrib['glyph'].lower().replace('uni', 'u')
-    if ligatureSet.startswith('u'): #TODO: parse missing emojis
+    if ligatureSet.startswith('u'):  # TODO: parse missing emojis
         for ligatureXml in ligatureSetXml:
-            component = ligatureXml.attrib['components'].replace(',', '_').lower().replace('uni', 'u')
+            component = ligatureXml.attrib['components']\
+                .replace(',', '_')\
+                .lower()\
+                .replace('uni', 'u')
             glyph = ligatureXml.attrib['glyph']
             print 'Renaming emoji_' + glyph + '.png to emoji_' + ligatureSet + '_' + component + '.png'
             try:

--- a/scripts/emoji-extractor/emoji-extractor.py
+++ b/scripts/emoji-extractor/emoji-extractor.py
@@ -31,6 +31,7 @@ font_xml = io.StringIO()
 TTFont(args.input).saveXML(font_xml)
 ttx = ElementTree.fromstring(font_xml.getvalue())
 
+
 def mass_rename(ligature_set_or_emoji):
     cmap = ttx.find('cmap').find('cmap_format_12')
     code = ''
@@ -41,12 +42,14 @@ def mass_rename(ligature_set_or_emoji):
             rename('emoji_{}.png'.format(ligature_set_or_emoji),
                    'emoji_u{}.png'.format(code))
 
+
 def rename(old_name, new_name):
     print('Renaming {} to {}'.format(old_name, new_name))
     try:
         (path / old_name).rename(path / new_name)
     except:
         print('!! Cannot rename {}'.format(old_name))
+
 
 for element in ttx.find('CBDT').find('strikedata'):
     data = element.find('rawimagedata').text.split()

--- a/scripts/emoji-extractor/emoji-extractor.py
+++ b/scripts/emoji-extractor/emoji-extractor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import os
 import shutil
@@ -40,7 +40,7 @@ for element in ttx.find('CBDT').find('strikedata'):
     name = element.attrib['name'].lower()
     name = name.replace('uni', 'u')
     imagePath = os.path.abspath(args.output + 'emoji_' + name + '.png')
-    print 'Extracting emoji_' + name + '.png'
+    print('Extracting emoji_' + name + '.png')
     emoji = open(imagePath, "wb")
     for char in data:
             hexChar = binascii.unhexlify(char)
@@ -56,11 +56,11 @@ for ligatureSetXml in ttx.find('GSUB').find('LookupList').find('Lookup').find('L
                 .lower()\
                 .replace('uni', 'u')
             glyph = ligatureXml.attrib['glyph']
-            print 'Renaming emoji_' + glyph + '.png to emoji_' + ligatureSet + '_' + component + '.png'
+            print('Renaming emoji_' + glyph + '.png to emoji_' + ligatureSet + '_' + component + '.png')
             try:
                 os.rename(args.output + '/emoji_' + glyph + '.png', args.output + '/emoji_' + ligatureSet + '_' + component + '.png')
             except:
-                print '!! Cannot rename emoji_' + glyph + '.png'
+                print('!! Cannot rename emoji_' + glyph + '.png')
     else:
         cmap = ttx.find('cmap').find('cmap_format_12')
         code = ''
@@ -73,16 +73,16 @@ for ligatureSetXml in ttx.find('GSUB').find('LookupList').find('Lookup').find('L
                 try:
                     os.rename(args.output + '/emoji_' + ligatureSet + '.png', args.output + '/emoji_u' + code + '.png')
                 except:
-                    print '!! Cannot rename emoji_' + ligatureSet + '.png'
+                    print('!! Cannot rename emoji_' + ligatureSet + '.png')
         else:
             if code == '':
-                print 'Ignoring ' + ligatureSet + '...'
+                print('Ignoring ' + ligatureSet + '...')
 
 emojis = glob.glob(args.output + './*.png')
 for emoji in emojis:
     if not emoji.startswith(args.output + './emoji_u'):
         emoji = emoji.replace(args.output + './emoji_', '').replace('.png', '')
-        print 'Fixing ' + emoji + '...'
+        print('Fixing ' + emoji + '...')
         cmap = ttx.find('cmap').find('cmap_format_12')
         code = ''
         for mapElement in cmap:
@@ -94,7 +94,7 @@ for emoji in emojis:
                 try:
                     os.rename(args.output + '/emoji_' + emoji + '.png', args.output + '/emoji_u' + code + '.png')
                 except:
-                    print '!! Cannot fix emoji_' + emoji + '.png'
+                    print('!! Cannot fix emoji_' + emoji + '.png')
 
 # Some flags aren't correctly sorted
 os.rename(args.output + '/emoji_ufe4e5.png', args.output + '/emoji_u1f1ef_u1f1f5.png')

--- a/scripts/emoji-extractor/emoji-extractor.py
+++ b/scripts/emoji-extractor/emoji-extractor.py
@@ -2,7 +2,7 @@
 
 import argparse
 import binascii
-import io
+from time import time
 import shutil
 from pathlib import Path
 import xml.etree.ElementTree as ElementTree
@@ -24,33 +24,46 @@ parser.add_argument(
 args = parser.parse_args()
 
 path = Path(args.output)
+
+# Clean working directory
 shutil.rmtree(path, ignore_errors=True)
 path.mkdir()
 
-font_xml = io.StringIO()
-TTFont(args.input).saveXML(font_xml)
-ttx = ElementTree.fromstring(font_xml.getvalue())
+# Load font data
+print("Loading font data...")
+
+t0 = time()
+font = TTFont(args.input)
+font.saveXML('.NotoColorEmoji.ttx')
+ttx = ElementTree.parse('.NotoColorEmoji.ttx').getroot()
+print("Time:", time() - t0)
 
 
-def mass_rename(ligature_set_or_emoji):
+def rename_to_resolved_unicode(glyph_name):
+    """Use TTF cmap (name <-> Unicode code point) mapping to rename an extracted glyph"""
+    glyph_name = str(glyph_name)  # In case it's a path
     cmap = ttx.find('cmap').find('cmap_format_12')
-    code = ''
     for map_element in cmap:
-        if map_element.attrib['name'].lower() == ligature_set_or_emoji:
+        if map_element.attrib['name'].lower() == glyph_name:
             replace_s = '' if len(map_element.attrib['code']) > 4 else '00'
             code = map_element.attrib['code'].replace('0x', replace_s)
-            rename('emoji_{}.png'.format(ligature_set_or_emoji),
+            rename_to('emoji_{}.png'.format(glyph_name),
                    'emoji_u{}.png'.format(code))
+            break  # Accelerate processing
+    else:
+        print('Ignoring ' + glyph_name + '...')
 
 
-def rename(old_name, new_name):
+def rename_to(old_name, new_name):
+    """Rename an extracted glyph"""
     print('Renaming {} to {}'.format(old_name, new_name))
     try:
         (path / old_name).rename(path / new_name)
-    except:
-        print('!! Cannot rename {}'.format(old_name))
+    except FileNotFoundError as ex:
+        print(ex.strerror)
 
 
+# Extract all emojis
 for element in ttx.find('CBDT').find('strikedata'):
     data = element.find('rawimagedata').text.split()
     name = element.attrib['name'].lower().replace('uni', 'u')
@@ -62,6 +75,7 @@ for element in ttx.find('CBDT').find('strikedata'):
         emoji.write(hexChar)
     emoji.close()
 
+print('*** Fixing names of compound emojis ***')
 for ligature_set_xml in ttx.find('GSUB')\
         .find('LookupList')\
         .find('Lookup')\
@@ -73,17 +87,18 @@ for ligature_set_xml in ttx.find('GSUB')\
                 .replace(',', '_')\
                 .replace('uni', 'u')
             glyph = ligature_xml.attrib['glyph']
-            rename('emoji_{}.png'.format(glyph),
-                   'emoji_{}_{}.png'.format(ligature_set, component))
+            if (path / 'emoji_{}.png'.format(glyph)).exists():
+                rename_to('emoji_{}.png'.format(glyph),
+                    'emoji_{}_{}.png'.format(ligature_set, component))
     else:
-        mass_rename(ligature_set)
+        rename_to_resolved_unicode(ligature_set)
 
+print('*** Fixing remaining names ***')
 emojis = path.glob('*.png')
 for emoji in emojis:
     if not emoji.name.startswith('emoji_u'):
         emoji = emoji.with_name(emoji.name.replace('emoji_', '').replace('.png', ''))
-        print('Fixing {}...'.format(emoji.name))
-        mass_rename(emoji)
+        rename_to_resolved_unicode(emoji.name)
 
 # Some flags aren't correctly sorted
 trans_table = {
@@ -99,8 +114,8 @@ trans_table = {
     'fe4ee': '1f1f0_u1f1f7',
 }
 
+# Fix these flag names
 for old, new in trans_table.items():
-    old_path = path / 'emoji_u{}.png'.format(old)
-    new_path = path / 'emoji_u{}.png'.format(new)
-    print('Renaming incorrect {} to {}'.format(old_path.name, new_path.name))
-    old_path.rename(new_path)
+    old_name = 'emoji_u{}.png'.format(old)
+    new_name = 'emoji_u{}.png'.format(new)
+    rename_to(old_name, new_name)

--- a/scripts/emoji-extractor/emoji-extractor.py
+++ b/scripts/emoji-extractor/emoji-extractor.py
@@ -56,11 +56,11 @@ for element in ttx.find('CBDT').find('strikedata'):
     name = element.attrib['name'].lower().replace('uni', 'u')
     image_path = path / 'emoji_{}.png'.format(name)
     print('Extracting {}'.format(image_path.name))
-    emoji = open(image_path, "wb")
+    emoji = open(str(image_path), "wb")
     for char in data:
         hexChar = binascii.unhexlify(char)
         emoji.write(hexChar)
-    emoji.close
+    emoji.close()
 
 for ligature_set_xml in ttx.find('GSUB')\
         .find('LookupList')\

--- a/scripts/emoji-extractor/gen-sprite.py
+++ b/scripts/emoji-extractor/gen-sprite.py
@@ -34,54 +34,54 @@ args = parser.parse_args()
 emoji_path = Path(args.emojis)
 
 xml = ElementTree.parse(args.xml).getroot()
-parsedItems = []
+parsed_items = []
 
 for group in xml:
-    groupName = group.attrib['name']
+    group_name = group.attrib['name']
     emojis = []
-    output = open('{}.txt'.format(groupName), 'w')
+    output = open('{}.txt'.format(group_name), 'w')
     for item in group:
         emoji = item.text.replace(',', '_u').lower()
         emoji_file = emoji_path / 'emoji_u{}.png'.format(emoji)
-        if '|' not in emoji and emoji not in parsedItems and emoji_file.is_file():
-            parsedItems.append(emoji)
+        if '|' not in emoji and emoji not in parsed_items and emoji_file.is_file():
+            parsed_items.append(emoji)
             emojis.append(emoji_file)
-            emojiCodePoint = '\\U' + emoji.replace('_u', '\\U')
-            emojiCodePoint = emojiCodePoint.split('\\U')
-            finalCodePoints = []
-            for point in emojiCodePoint:
+            emoji_code_point = '\\U' + emoji.replace('_u', '\\U')
+            emoji_code_point = emoji_code_point.split('\\U')
+            final_code_points = []
+            for point in emoji_code_point:
                 point = point.replace('\\U', '')
                 if len(point) > 0:
                     if len(point) < 8:
                         point = "0" * (8 - len(point)) + point
-                    finalCodePoints.append(point)
-            char = '\\U' + '\\U'.join(finalCodePoints)
+                    final_code_points.append(point)
+            char = '\\U' + '\\U'.join(final_code_points)
             output.write(char + '\n')
     images = [Image.open(filename) for filename in emojis]
     output.close()
 
     if len(images) > 0:
-        print("Generating sprite for {}".format(groupName))
-        masterWidth = (128 * int(args.size))
+        print("Generating sprite for {}".format(group_name))
+        master_width = (128 * int(args.size))
         lines = len(images) / float(args.size)
         if not lines.is_integer():
             lines = int(lines + 1)
-        masterHeight = int(128 * lines)
+        master_height = int(128 * lines)
         master = Image.new(
             mode='RGBA',
-            size=(masterWidth, masterHeight),
+            size=(master_width, master_height),
             color=(0, 0, 0, 0)
         )
 
         offset = -1
         for count, image in enumerate(images):
-            location = (128 * count) % masterWidth
+            location = (128 * count) % master_width
             if location == 0:
                 offset += 1
             master.paste(image, (location, 128 * offset))
-        ratio = masterWidth / float(args.resize)
-        newHeight = int(masterHeight // ratio)
-        master = master.resize((int(args.resize), newHeight))
-        master.save(groupName + '.png', 'PNG')
+        ratio = master_width / float(args.resize)
+        new_height = int(master_height // ratio)
+        master = master.resize((int(args.resize), new_height))
+        master.save(group_name + '.png', 'PNG')
     else:
-        print('Ignoring {}...'.format(groupName))
+        print('Ignoring {}...'.format(group_name))

--- a/scripts/emoji-extractor/gen-sprite.py
+++ b/scripts/emoji-extractor/gen-sprite.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import math
 from pathlib import Path
 import xml.etree.ElementTree as ElementTree
 
@@ -46,10 +47,9 @@ for group in xml:
         if '|' not in emoji and emoji not in parsed_items and emoji_file.is_file():
             parsed_items.append(emoji)
             emojis.append(emoji_file)
-            emoji_code_point = '\\U' + emoji.replace('_u', '\\U')
-            emoji_code_point = emoji_code_point.split('\\U')
             final_code_points = []
-            for point in emoji_code_point:
+            emoji_code_point = '\\U' + emoji.replace('_u', '\\U')
+            for point in emoji_code_point.split('\\U'):
                 point = point.replace('\\U', '')
                 if len(point) > 0:
                     if len(point) < 8:
@@ -62,11 +62,9 @@ for group in xml:
 
     if len(images) > 0:
         print("Generating sprite for {}".format(group_name))
-        master_width = (128 * int(args.size))
-        lines = len(images) / float(args.size)
-        if not lines.is_integer():
-            lines = int(lines + 1)
-        master_height = int(128 * lines)
+        master_width = 128 * int(args.size)
+        lines = math.ceil(len(images) / float(args.size))
+        master_height = 128 * int(lines)
         master = Image.new(
             mode='RGBA',
             size=(master_width, master_height),
@@ -79,9 +77,9 @@ for group in xml:
             if location == 0:
                 offset += 1
             master.paste(image, (location, 128 * offset))
-        ratio = master_width / float(args.resize)
-        new_height = int(master_height // ratio)
-        master = master.resize((int(args.resize), new_height))
+        ratio = float(master_width) / float(args.resize)
+        new_height = math.ceil(master_height / ratio)
+        master = master.resize((int(args.resize), int(new_height)))
         master.save(group_name + '.png', 'PNG')
     else:
         print('Ignoring {}...'.format(group_name))

--- a/scripts/emoji-extractor/gen-sprite.py
+++ b/scripts/emoji-extractor/gen-sprite.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python2
-from __future__ import unicode_literals
+#!/usr/bin/env python3
 
 import os
 from PIL import Image
@@ -54,12 +53,12 @@ for group in xml:
                         point = "0" * (8 - len(point)) + point
                     finalCodePoints.append(point)
             char = '\\U' + '\\U'.join(finalCodePoints)
-            output.write(char.decode('unicode_escape') + '\n')
+            output.write(char + '\n')
     images = [Image.open(filename) for filename in emojis]
     output.close()
 
     if len(images) > 0:
-        print "Generating sprite for " + groupName
+        print("Generating sprite for " + groupName)
         masterWidth = (128 * int(args.size))
         lines = float(len(images)) / float(args.size)
         if not lines.is_integer():
@@ -84,4 +83,4 @@ for group in xml:
         master = master.resize((int(args.resize), newHeight))
         master.save(groupName + '.png', 'PNG')
     else:
-        print 'Ignoring ' + groupName + '...'
+        print('Ignoring ' + groupName + '...')

--- a/scripts/emoji-extractor/gen-sprite.py
+++ b/scripts/emoji-extractor/gen-sprite.py
@@ -7,11 +7,29 @@ import argparse
 import xml.etree.ElementTree as ElementTree
 import io
 
-parser = argparse.ArgumentParser(prog='gen-sprite', description="""Generate sprites from extracted emojis.""")
-parser.add_argument('-e', '--emojis', help='folder where emojis are stored', default='output/', required=False)
-parser.add_argument('-i', '--xml', help='XML containing emojis map', default='emoji-categories.xml', required=False)
-parser.add_argument('-s', '--size', help='Maximum number of emojis per line', default='15', required=False)
-parser.add_argument('-r', '--resize', help='Maximum width for sprites', default='1530', required=False)
+parser = argparse.ArgumentParser(
+    prog='gen-sprite',
+    description="""Generate sprites from extracted emojis.""")
+parser.add_argument(
+    '-e', '--emojis',
+    help='folder where emojis are stored',
+    default='output/',
+    required=False)
+parser.add_argument(
+    '-i', '--xml',
+    help='XML containing emojis map',
+    default='emoji-categories.xml',
+    required=False)
+parser.add_argument(
+    '-s', '--size',
+    help='Maximum number of emojis per line',
+    default='15',
+    required=False)
+parser.add_argument(
+    '-r', '--resize',
+    help='Maximum width for sprites',
+    default='1530',
+    required=False)
 args = parser.parse_args()
 
 xml = ElementTree.parse(args.xml).getroot()
@@ -40,10 +58,9 @@ for group in xml:
     images = [Image.open(filename) for filename in emojis]
     output.close()
 
-
     if len(images) > 0:
         print "Generating sprite for " + groupName
-        masterWidth  = (128 * int(args.size))
+        masterWidth = (128 * int(args.size))
         lines = float(len(images)) / float(args.size)
         if not lines.is_integer():
             lines += 1
@@ -52,7 +69,7 @@ for group in xml:
         master = Image.new(
             mode='RGBA',
             size=(masterWidth, masterHeight),
-            color=(0,0,0,0)
+            color=(0, 0, 0, 0)
         )
 
         offset = -1

--- a/scripts/emoji-extractor/remove-emoji-margins.py
+++ b/scripts/emoji-extractor/remove-emoji-margins.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import os
 import argparse
@@ -17,11 +17,11 @@ args = parser.parse_args()
 for element in os.listdir(args.emojis):
     imagePath = os.path.abspath(args.emojis + element)
     try:
-        print 'Cropping ' + element + '...'
+        print('Cropping ' + element + '...')
         image = Image.open(imagePath)
         width, height = image.size
         box = (4, 0, width - 4, height)
         crop = image.crop(box)
         crop.save(imagePath)
     except:
-        print 'Cannot crop emoji_' + name + '.png...'
+        print('Cannot crop emoji_' + name + '.png...')

--- a/scripts/emoji-extractor/remove-emoji-margins.py
+++ b/scripts/emoji-extractor/remove-emoji-margins.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 import argparse
-
 from pathlib import Path
+
 from PIL import Image
 
 parser = argparse.ArgumentParser(

--- a/scripts/emoji-extractor/remove-emoji-margins.py
+++ b/scripts/emoji-extractor/remove-emoji-margins.py
@@ -2,10 +2,16 @@
 
 import os
 import argparse
-from PIL import Image, ImageChops
+from PIL import Image
 
-parser = argparse.ArgumentParser(prog='emoji-extractor', description="""Resize extracted emojis to 128x128.""")
-parser.add_argument('-e', '--emojis', help='folder where emojis are stored', default='output/', required=False)
+parser = argparse.ArgumentParser(
+    prog='emoji-extractor',
+    description="""Resize extracted emojis to 128x128.""")
+parser.add_argument(
+    '-e', '--emojis',
+    help='folder where emojis are stored',
+    default='output/',
+    required=False)
 args = parser.parse_args()
 
 for element in os.listdir(args.emojis):
@@ -14,7 +20,7 @@ for element in os.listdir(args.emojis):
         print 'Cropping ' + element + '...'
         image = Image.open(imagePath)
         width, height = image.size
-        box = (4, 0, width-4, height)
+        box = (4, 0, width - 4, height)
         crop = image.crop(box)
         crop.save(imagePath)
     except:

--- a/scripts/emoji-extractor/remove-emoji-margins.py
+++ b/scripts/emoji-extractor/remove-emoji-margins.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-import os
 import argparse
+
+from pathlib import Path
 from PIL import Image
 
 parser = argparse.ArgumentParser(
@@ -14,14 +15,15 @@ parser.add_argument(
     required=False)
 args = parser.parse_args()
 
-for element in os.listdir(args.emojis):
-    imagePath = os.path.abspath(args.emojis + element)
+path = Path(args.emojis)
+
+for image_path in path.iterdir():
     try:
-        print('Cropping ' + element + '...')
-        image = Image.open(imagePath)
+        print('Cropping {}...'.format(image_path.name))
+        image = Image.open(image_path)
         width, height = image.size
         box = (4, 0, width - 4, height)
         crop = image.crop(box)
-        crop.save(imagePath)
+        crop.save(image_path)
     except:
-        print('Cannot crop emoji_' + name + '.png...')
+        print('Cannot crop {}...'.format(image_path.name))


### PR DESCRIPTION
Migrates emoji-extractor script to Python3, improving code style (PEP8, etc). Adapts work done by ariasuni in PR #575.

Tested against both Python 3.6 (latest stable 3.X) and 3.4 (earliest stable 3.X) by running on NotoColorEmoji.ttf from googlei18n/noto-emoji.

