### PR TITLE
Removed com.madgag.spongycastle:prov dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     compile ("com.doomonafireball.betterpickers:library:1.5.3") {
         exclude group: 'com.android.support', module: 'support-v4'
     }
-    compile 'com.madgag.spongycastle:prov:1.51.0.0'
     provided 'com.squareup.dagger:dagger-compiler:1.2.2'
 
     compile project (':org.whispersystems.jobmanager')
@@ -112,7 +111,6 @@ dependencyVerification {
             'com.android.support:transition:cf53f778352fe0b74ff14d838bef9fe79264f3fd43eac499b6e0d1664dbd8997',
             'com.android.support:gridlayout-v7:a9b770cffca2c7c5cd83cba4dd12503365de5e8d9c79c479165adf18ab3bc25b',
             'com.doomonafireball.betterpickers:library:132ecd685c95a99e7377c4e27bfadbb2d7ed0bea995944060cd62d4369fdaf3d',
-            'com.madgag.spongycastle:prov:b8c3fec3a59aac1aa04ccf4dad7179351e54ef7672f53f508151b614c131398a',
             'com.fasterxml.jackson.core:jackson-annotations:6b7802f6c22c09c4a92a2ebeb76e755c3c0a58dfbf419835fae470d89e469b86',
             'com.fasterxml.jackson.core:jackson-core:256ff34118ab292d1b4f3ee4d2c3e5e5f0f609d8e07c57e8ad1f51c46d4fbb46',
             'com.fasterxml.jackson.core:jackson-databind:4f74337b6d18664be0f5b15c6664b17aa3972c9c175092328b139b894ff66f19',

--- a/src/org/smssecure/smssecure/attachments/AttachmentServer.java
+++ b/src/org/smssecure/smssecure/attachments/AttachmentServer.java
@@ -6,9 +6,9 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
-import org.spongycastle.util.encoders.Hex;
 import org.smssecure.smssecure.crypto.MasterSecret;
 import org.smssecure.smssecure.mms.PartAuthority;
+import org.smssecure.smssecure.util.Hex;
 import org.smssecure.smssecure.util.Util;
 
 import java.io.BufferedOutputStream;
@@ -54,7 +54,7 @@ public class AttachmentServer implements Runnable {
       this.attachment   = attachment;
       this.socket       = new ServerSocket(0, 0, InetAddress.getByAddress(new byte[]{127, 0, 0, 1}));
       this.port         = socket.getLocalPort();
-      this.auth         = new String(Hex.encode(Util.getSecretBytes(16)));
+      this.auth         = Hex.toStringCondensed(Util.getSecretBytes(16));
 
       this.socket.setSoTimeout(5000);
     } catch (UnknownHostException e) {

--- a/test/unitTest/java/org/smssecure/smssecure/util/HexTest.java
+++ b/test/unitTest/java/org/smssecure/smssecure/util/HexTest.java
@@ -1,0 +1,37 @@
+package org.smssecure.smssecure.util;
+
+import org.junit.Test;
+import java.io.IOException;
+import static junit.framework.Assert.assertEquals;
+
+public class HexTest {
+    private byte[] testBytes = new byte[16];//Just bytes
+    {
+        for(int i=0;i<16;i++){
+            testBytes[i] = (byte) i;
+        }
+    }
+    @Test public void testBytesToStringCondensed() {
+        String hexOfTestBytes = "000102030405060708090a0b0c0d0e0f";
+        assertEquals(hexOfTestBytes,Hex.toStringCondensed(testBytes));
+    }
+    @Test public void testBytesToString() {
+        String hexOfTestBytes = "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f ";
+        assertEquals(hexOfTestBytes,Hex.toString(testBytes));
+    }
+    @Test public void testFromStringCondensed() throws IOException {
+        assertEquals("000102030405060708090a0b0c0d0e0f",
+                Hex.toStringCondensed(
+                        Hex.fromStringCondensed("000102030405060708090a0b0c0d0e0f")
+                )
+        );
+    }
+    @Test public void testBytesDump() {
+        String hexOfTestBytes = "00000000: 0001 0203 0405 0607 0809 0a0b 0c0d 0e0f ................\n";
+        assertEquals(hexOfTestBytes,Hex.dump(testBytes));
+    }
+    @Test public void testBytesDumpWithOffset() {
+        String hexOfTestBytes = "00000000: 0304 0506 0708 09                       .......\n";
+        assertEquals(hexOfTestBytes,Hex.dump(testBytes,3,7));
+    }
+}


### PR DESCRIPTION
I removed the ```com.madgag.spongycastle``` dependency to reduce the number of dependencies of Signal and because it makes a lot of code that is unused.

I added tests for most of the code of ```class org.smssecure.smssecure.util.Hex```

I hope @BLeQuerrec that you will be interested by this PR.